### PR TITLE
feat(HubPool): Second iteration on init, dispute and execute relayer refund bundles

### DIFF
--- a/contracts/HubPool.sol
+++ b/contracts/HubPool.sol
@@ -57,7 +57,7 @@ contract HubPool is Testable, Lockable, MultiCaller, Ownable {
     // The computed bond amount as the UMA Store's final fee multiplied by the bondTokenFinalFeeMultiplier.
     uint256 public bondAmount;
 
-    // Each refund proposal must stay in liveness for at least this long until it can be considered finalized. It can
+    // Each refund proposal must stay in liveness for this period of time before it can be considered finalized. It can
     // be disputed only during this period of time.
     uint64 public refundProposalLiveness;
 

--- a/contracts/HubPool.sol
+++ b/contracts/HubPool.sol
@@ -31,12 +31,6 @@ contract HubPool is Testable, Lockable, MultiCaller, Ownable {
         bool isEnabled;
     }
 
-    enum RefundRequestStatus {
-        Pending, // Request is in liveness and waiting
-        Finalized,
-        Disputed
-    }
-
     struct RelayerRefundRequest {
         uint64 requestExpirationTimestamp;
         uint64 unclaimedPoolRebalanceLeafs;

--- a/contracts/HubPool.sol
+++ b/contracts/HubPool.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-only
 pragma solidity ^0.8.0;
 
+import "./MerkleLib.sol";
+
 import "@uma/core/contracts/common/implementation/Testable.sol";
 import "@uma/core/contracts/common/implementation/Lockable.sol";
 import "@uma/core/contracts/common/implementation/MultiCaller.sol";
@@ -30,15 +32,19 @@ contract HubPool is Testable, Lockable, MultiCaller, Ownable {
     }
 
     enum RefundRequestStatus {
-        Pending,
+        Pending, // Request is in liveness and waiting
         Finalized,
         Disputed
     }
 
     struct RelayerRefundRequest {
-        bytes32 poolRebalanceProof;
-        bytes32 destinationDistributionProof;
-        RefundRequestStatus status;
+        uint64 requestExpirationTimestamp;
+        uint64 unclaimedPoolRebalanceLeafs;
+        bytes32 poolRebalanceRoot;
+        bytes32 destinationDistributionRoot;
+        mapping(uint256 => uint256) claimedBitMap;
+        address proposer;
+        bool proposerBondRepaid;
     }
 
     RelayerRefundRequest[] public relayerRefundRequests;
@@ -57,8 +63,9 @@ contract HubPool is Testable, Lockable, MultiCaller, Ownable {
     // The computed bond amount as the UMA Store's final fee multiplied by the bondTokenFinalFeeMultiplier.
     uint256 public bondAmount;
 
-    // There should only ever be one refund proposal pending at any point in time. This bool toggles accordingly.
-    bool public currentPendingRefundProposal = false;
+    // Each refund proposal must stay in liveness for at least this long until it can be considered finalized. It can
+    // be disputed only during this period of time.
+    uint64 public refundProposalLiveness;
 
     event BondAmountSet(uint64 newBondMultiplier);
 
@@ -79,20 +86,32 @@ contract HubPool is Testable, Lockable, MultiCaller, Ownable {
     event WhitelistRoute(address originToken, uint256 destinationChainId, address destinationToken);
 
     event RelayerRefundRequested(
-        uint64 relayerRefundId,
+        uint64 indexed relayerRefundId,
+        uint64 requestExpirationTimestamp,
+        uint64 poolRebalanceLeafCount,
         uint256[] bundleEvaluationBlockNumbers,
-        bytes32 indexed poolRebalanceProof,
-        bytes32 indexed destinationDistributionProof,
-        address proposer
+        bytes32 poolRebalanceRoot,
+        bytes32 destinationDistributionRoot,
+        address indexed proposer
     );
+    event RelayerRefundExecuted(
+        uint256 relayerRefundId,
+        MerkleLib.PoolRebalance poolRebalance,
+        bytes32[] proof,
+        address caller
+    );
+
+    event RelayerRefundDisputed(uint256 relayerRefundId, address disputer);
 
     constructor(
         uint256 _bondAmount,
+        uint64 _refundProposalLiveness,
         address _bondToken,
         address _l1Weth,
         address _timerAddress
     ) Testable(_timerAddress) {
         bondAmount = _bondAmount;
+        refundProposalLiveness = _refundProposalLiveness;
         bondToken = IERC20(_bondToken);
         l1Weth = WETH9Like(_l1Weth);
     }
@@ -201,48 +220,101 @@ contract HubPool is Testable, Lockable, MultiCaller, Ownable {
 
     function initiateRelayerRefund(
         uint256[] memory bundleEvaluationBlockNumbers,
-        bytes32 poolRebalanceProof,
-        bytes32 destinationDistributionProof
+        uint64 poolRebalanceLeafCount,
+        bytes32 poolRebalanceRoot,
+        bytes32 destinationDistributionRoot
     ) public {
-        require(currentPendingRefundProposal == false, "Only one proposal at a time");
-        currentPendingRefundProposal = true;
-        relayerRefundRequests.push(
-            RelayerRefundRequest({
-                poolRebalanceProof: poolRebalanceProof,
-                destinationDistributionProof: destinationDistributionProof,
-                status: RefundRequestStatus.Pending
-            })
+        // The most recent refund proposal must be fully claimed before the next relayer refund bundle is initiated.
+        require(
+            relayerRefundRequests.length == 0 || // If this is the first initiated relay refund.
+                relayerRefundRequests[getNumberOfRelayRefunds()].unclaimedPoolRebalanceLeafs == 0,
+            "Last bundle has unclaimed leafs"
         );
+
+        uint64 requestExpirationTimestamp = uint64(getCurrentTime() + refundProposalLiveness);
+        uint256 relayerRefundId = relayerRefundRequests.length;
+        relayerRefundRequests.push();
+        relayerRefundRequests[relayerRefundId].requestExpirationTimestamp = requestExpirationTimestamp;
+        relayerRefundRequests[relayerRefundId].unclaimedPoolRebalanceLeafs = poolRebalanceLeafCount;
+        relayerRefundRequests[relayerRefundId].poolRebalanceRoot = poolRebalanceRoot;
+        relayerRefundRequests[relayerRefundId].destinationDistributionRoot = destinationDistributionRoot;
+        relayerRefundRequests[relayerRefundId].proposer = msg.sender;
 
         // Pull bondAmount of bondToken from the caller.
         bondToken.safeTransferFrom(msg.sender, address(this), bondAmount);
 
         emit RelayerRefundRequested(
-            uint64(relayerRefundRequests.length - 1), // Index of the relayerRefundRequest within the array.
+            uint64(relayerRefundId),
+            requestExpirationTimestamp,
+            poolRebalanceLeafCount,
             bundleEvaluationBlockNumbers,
-            poolRebalanceProof,
-            destinationDistributionProof,
+            poolRebalanceRoot,
+            destinationDistributionRoot,
             msg.sender
         );
     }
 
     function executeRelayerRefund(
         uint256 relayerRefundRequestId,
-        uint256 leafId,
-        uint256 repaymentChainId,
-        address[] memory l1TokenAddress,
-        uint256[] memory accumulatedLpFees,
-        uint256[] memory netSendAmounts,
-        bytes32[] memory inclusionProof
-    ) public {}
+        MerkleLib.PoolRebalance memory poolRebalance,
+        bytes32[] memory proof
+    ) public {
+        RelayerRefundRequest storage relayerRefund = relayerRefundRequests[relayerRefundRequestId];
+        require(getCurrentTime() > relayerRefund.requestExpirationTimestamp, "Not passed liveness");
 
-    function disputeRelayerRefund() public {}
+        // Verify the leafId in the poolRebalance has not yet been claimed.
+        require(!MerkleLib.isClaimed(relayerRefund.claimedBitMap, poolRebalance.leafId), "Already claimed");
+
+        // Verify the props provided generate a leaf that, along with the proof, are included in the merkle root.
+        require(MerkleLib.verifyPoolRebalance(relayerRefund.poolRebalanceRoot, poolRebalance, proof), "Bad Proof");
+
+        // Set the leafId in the claimed bitmap.
+        MerkleLib.setClaimed(relayerRefund.claimedBitMap, poolRebalance.leafId);
+
+        // Decrement the unclaimedPoolRebalanceLeafs.
+        relayerRefund.unclaimedPoolRebalanceLeafs--;
+
+        // Transfer the bondAmount to back to the proposer, if this was not done before for this refund bundle.
+        if (!relayerRefund.proposerBondRepaid) {
+            relayerRefund.proposerBondRepaid = true;
+            bondToken.safeTransfer(relayerRefund.proposer, bondAmount);
+        }
+
+        // TODO call into canonical bridge to send PoolRebalance.netSendAmount for the associated
+        // PoolRebalance.tokenAddresses, to the target PoolRebalance.chainId. this will likely happen within a
+        // x_Messenger contract for each chain. these messengers will be registered in a separate process that will follow
+        // in a later PR.
+        // TODO: modify the associated utilized and pending reserves for each token sent.
+
+        emit RelayerRefundExecuted(relayerRefundRequestId, poolRebalance, proof, msg.sender);
+    }
+
+    function disputeRelayerRefund(uint256 relayerRefundRequestId) public {
+        RelayerRefundRequest storage relayerRefund = relayerRefundRequests[relayerRefundRequestId];
+        require(
+            getCurrentTime() > relayerRefundRequests[relayerRefundRequestId].requestExpirationTimestamp,
+            "Passed liveness"
+        );
+
+        // Delete the last element in the relayerRefundRequests array. This acts to throw out the request.
+        emit RelayerRefundDisputed(relayerRefundRequestId, msg.sender);
+
+        relayerRefundRequests.pop();
+
+        // TODO: pull bonds. request price from OO.
+    }
+
+    function getNumberOfRelayRefunds() public view returns (uint256) {
+        if (relayerRefundRequests.length == 0) return 0;
+        return relayerRefundRequests.length - 1;
+    }
 
     /*************************************************
      *              INTERNAL FUNCTIONS               *
      *************************************************/
 
     function _exchangeRateCurrent() internal pure returns (uint256) {
+        // TODO: implement this method to consider utilization.
         return 1e18;
     }
 

--- a/contracts/MerkleLib.sol
+++ b/contracts/MerkleLib.sol
@@ -57,7 +57,7 @@ library MerkleLib {
      * @param repayment the repayment struct.
      * @param proof the merkle proof.
      */
-    function verifyRepayment(
+    function verifyPoolRebalance(
         bytes32 root,
         PoolRebalance memory repayment,
         bytes32[] memory proof
@@ -71,7 +71,7 @@ library MerkleLib {
      * @param distribution the distribution struct.
      * @param proof the merkle proof.
      */
-    function verifyDistribution(
+    function verifyRelayerDistribution(
         bytes32 root,
         DestinationDistribution memory distribution,
         bytes32[] memory proof

--- a/test/HubPool.Fixture.ts
+++ b/test/HubPool.Fixture.ts
@@ -1,6 +1,6 @@
 import { TokenRolesEnum } from "@uma/common";
 import { getContractFactory } from "./utils";
-import { bondAmount } from "./constants";
+import { bondAmount, refundProposalLiveness } from "./constants";
 import { Contract } from "ethers";
 
 export async function deployHubPoolTestHelperContracts(deployerWallet: any) {
@@ -17,7 +17,7 @@ export async function deployHubPoolTestHelperContracts(deployerWallet: any) {
   // Deploy the hubPool
   const hubPool = await (
     await getContractFactory("HubPool", deployerWallet)
-  ).deploy(bondAmount, weth.address, weth.address, timer.address);
+  ).deploy(bondAmount, refundProposalLiveness, weth.address, weth.address, timer.address);
 
   return { timer, weth, usdc, dai, hubPool };
 }

--- a/test/HubPool.RelayerRefund.ts
+++ b/test/HubPool.RelayerRefund.ts
@@ -35,7 +35,7 @@ describe("HubPool Relayer Refund", function () {
           destinationDistributionProof
         )
     )
-      .to.emit(hubPool, "RelayerRefundRequested")
+      .to.emit(hubPool, "InitiateRefundRequested")
       .withArgs(
         0,
         expectedRequestExpirationTimestamp,

--- a/test/HubPool.RelayerRefund.ts
+++ b/test/HubPool.RelayerRefund.ts
@@ -4,7 +4,7 @@ import { Contract } from "ethers";
 import { ethers } from "hardhat";
 import { ZERO_ADDRESS } from "@uma/common";
 import { getContractFactory, SignerWithAddress, createRandomBytes32, seedWallet } from "./utils";
-import { depositDestinationChainId, bondAmount } from "./constants";
+import { depositDestinationChainId, bondAmount, refundProposalLiveness } from "./constants";
 import { deployHubPoolTestHelperContracts } from "./HubPool.Fixture";
 
 let hubPool: Contract, weth: Contract, usdc: Contract;
@@ -19,26 +19,46 @@ describe("HubPool Relayer Refund", function () {
 
   it("Initialization of a relay correctly stores data, emits events and pulls the bond", async function () {
     const bundleEvaluationBlockNumbers = [1, 2, 3];
+    const poolRebalanceLeafCount = 5;
     const poolRebalanceProof = createRandomBytes32();
     const destinationDistributionProof = createRandomBytes32();
 
+    const expectedRequestExpirationTimestamp = Number(await hubPool.getCurrentTime()) + refundProposalLiveness;
     await weth.connect(dataWorker).approve(hubPool.address, bondAmount);
     await expect(
       hubPool
         .connect(dataWorker)
-        .initiateRelayerRefund(bundleEvaluationBlockNumbers, poolRebalanceProof, destinationDistributionProof)
+        .initiateRelayerRefund(
+          bundleEvaluationBlockNumbers,
+          poolRebalanceLeafCount,
+          poolRebalanceProof,
+          destinationDistributionProof
+        )
     )
       .to.emit(hubPool, "RelayerRefundRequested")
-      .withArgs(0, bundleEvaluationBlockNumbers, poolRebalanceProof, destinationDistributionProof, dataWorker.address);
+      .withArgs(
+        0,
+        expectedRequestExpirationTimestamp,
+        poolRebalanceLeafCount,
+        bundleEvaluationBlockNumbers,
+        poolRebalanceProof,
+        destinationDistributionProof,
+        dataWorker.address
+      );
     // Balances of the hubPool should have incremented by the bond and the dataWorker should have decremented by the bond.
     expect(await weth.balanceOf(hubPool.address)).to.equal(bondAmount);
     expect(await weth.balanceOf(dataWorker.address)).to.equal(0);
 
-    // Can only have one pending proposal at a time.
+    // Can not re-initialize if the previous bundle has unclaimed leaves.
     await expect(
       hubPool
         .connect(dataWorker)
-        .initiateRelayerRefund(bundleEvaluationBlockNumbers, poolRebalanceProof, destinationDistributionProof)
-    ).to.be.revertedWith("Only one proposal at a time");
+        .initiateRelayerRefund(
+          bundleEvaluationBlockNumbers,
+          poolRebalanceLeafCount,
+          poolRebalanceProof,
+          destinationDistributionProof
+        )
+    ).to.be.revertedWith("Last bundle has unclaimed leafs");
   });
 });

--- a/test/constants.ts
+++ b/test/constants.ts
@@ -13,3 +13,5 @@ export const depositRelayerFeePct = toWei("0.25");
 export const depositQuoteTimeBuffer = 10 * 60; // 10 minutes
 
 export const bondAmount = toWei("5"); // 5 ETH as the bond for proposing refund bundles.
+
+export const refundProposalLiveness = 100;

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,18 +1,24 @@
 import { getBytecode, getAbi } from "@uma/contracts-node";
 import { ethers } from "hardhat";
-import { BigNumber, Signer, Contract } from "ethers";
+import { BigNumber, Signer, Contract, ContractFactory } from "ethers";
 
 export interface SignerWithAddress extends Signer {
   address: string;
 }
 
-export async function getContractFactory(name: string, signer: SignerWithAddress) {
+export async function getContractFactory(name: string, signer: SignerWithAddress): Promise<ContractFactory> {
+  console.log("getting", name);
   try {
     // Try fetch from the local ethers factory from HRE. If this exists then the contract is in this package.
+    if (name == "HubPool") {
+      const merkleLib = await (await ethers.getContractFactory("MerkleLib")).deploy();
+      return await ethers.getContractFactory(name, { libraries: { MerkleLib: merkleLib.address } });
+    }
     return await ethers.getContractFactory(name);
-  } catch (error) {}
-  // If it does not exist then try find the contract in the UMA core package.
-  return new ethers.ContractFactory(getAbi(name as any), getBytecode(name as any), signer);
+  } catch (error) {
+    // If it does not exist then try find the contract in the UMA core package.
+    return new ethers.ContractFactory(getAbi(name as any), getBytecode(name as any), signer);
+  }
 }
 
 export const toWei = (num: string | number | BigNumber) => ethers.utils.parseEther(num.toString());

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -7,7 +7,6 @@ export interface SignerWithAddress extends Signer {
 }
 
 export async function getContractFactory(name: string, signer: SignerWithAddress): Promise<ContractFactory> {
-  console.log("getting", name);
   try {
     // Try fetch from the local ethers factory from HRE. If this exists then the contract is in this package.
     if (name == "HubPool") {


### PR DESCRIPTION
This PR adds the second iteration of `initiateRelayerRefund`, `disputeRelayerRefund` and `executeRelayerRefund`.