### PR TITLE
improve: move all tests to hardhat fixtures

### DIFF
--- a/test/HubPool.Admin.ts
+++ b/test/HubPool.Admin.ts
@@ -4,7 +4,7 @@ import { ethers } from "hardhat";
 import { ZERO_ADDRESS } from "@uma/common";
 import { getContractFactory, SignerWithAddress } from "./utils";
 import { depositDestinationChainId } from "./constants";
-import { deployHubPoolTestHelperContracts } from "./HubPool.Fixture";
+import { hubPoolFixture } from "./HubPool.Fixture";
 
 let hubPool: Contract, weth: Contract, usdc: Contract;
 let owner: SignerWithAddress, other: SignerWithAddress;
@@ -12,7 +12,7 @@ let owner: SignerWithAddress, other: SignerWithAddress;
 describe("HubPool Admin functions", function () {
   before(async function () {
     [owner, other] = await ethers.getSigners();
-    ({ weth, hubPool, usdc } = await deployHubPoolTestHelperContracts(owner));
+    ({ weth, hubPool, usdc } = await hubPoolFixture());
   });
 
   it("Can add L1 token to whitelisted lpTokens mapping", async function () {

--- a/test/HubPool.Fixture.ts
+++ b/test/HubPool.Fixture.ts
@@ -1,9 +1,12 @@
 import { TokenRolesEnum } from "@uma/common";
 import { getContractFactory } from "./utils";
 import { bondAmount, refundProposalLiveness } from "./constants";
-import { Contract } from "ethers";
+import { Contract, Signer } from "ethers";
+import hre from "hardhat";
 
-export async function deployHubPoolTestHelperContracts(deployerWallet: any) {
+export const hubPoolFixture = hre.deployments.createFixture(async ({ ethers }) => {
+  const [deployerWallet] = await ethers.getSigners();
+
   // Useful contracts.
   const timer = await (await getContractFactory("Timer", deployerWallet)).deploy();
 
@@ -21,9 +24,9 @@ export async function deployHubPoolTestHelperContracts(deployerWallet: any) {
   ).deploy(bondAmount, refundProposalLiveness, weth.address, weth.address, timer.address);
 
   return { timer, weth, usdc, dai, hubPool };
-}
+});
 
-export async function enableTokensForLiquidityProvision(owner: any, hubPool: Contract, tokens: Contract[]) {
+export async function enableTokensForLiquidityProvision(owner: Signer, hubPool: Contract, tokens: Contract[]) {
   const lpTokens = [];
   for (const token of tokens) {
     await hubPool.enableL1TokenForLiquidityProvision(token.address);

--- a/test/HubPool.LiquidityProvision.ts
+++ b/test/HubPool.LiquidityProvision.ts
@@ -2,7 +2,7 @@ import { expect } from "chai";
 import { Contract } from "ethers";
 import { ethers } from "hardhat";
 import { getContractFactory, fromWei, toBN, SignerWithAddress, seedWallet } from "./utils";
-import { deployHubPoolTestHelperContracts, enableTokensForLiquidityProvision } from "./HubPool.Fixture";
+import { hubPoolFixture, enableTokensForLiquidityProvision } from "./HubPool.Fixture";
 import { amountToSeedWallets, amountToLp } from "./constants";
 
 let hubPool: Contract, weth: Contract, usdc: Contract, dai: Contract;
@@ -12,7 +12,7 @@ let owner: SignerWithAddress, liquidityProvider: SignerWithAddress, other: Signe
 describe("HubPool Liquidity Provision", function () {
   beforeEach(async function () {
     [owner, liquidityProvider, other] = await ethers.getSigners();
-    ({ weth, usdc, dai, hubPool } = await deployHubPoolTestHelperContracts(owner));
+    ({ weth, usdc, dai, hubPool } = await hubPoolFixture());
     [wethLpToken, usdcLpToken, daiLpToken] = await enableTokensForLiquidityProvision(owner, hubPool, [weth, usdc, dai]);
 
     // mint some fresh tokens and deposit ETH for weth for the liquidity provider.

--- a/test/HubPool.RelayerRefund.ts
+++ b/test/HubPool.RelayerRefund.ts
@@ -5,7 +5,7 @@ import { ethers } from "hardhat";
 import { ZERO_ADDRESS } from "@uma/common";
 import { getContractFactory, SignerWithAddress, createRandomBytes32, seedWallet } from "./utils";
 import { depositDestinationChainId, bondAmount, refundProposalLiveness } from "./constants";
-import { deployHubPoolTestHelperContracts } from "./HubPool.Fixture";
+import { hubPoolFixture } from "./HubPool.Fixture";
 
 let hubPool: Contract, weth: Contract, usdc: Contract;
 let owner: SignerWithAddress, dataWorker: SignerWithAddress;
@@ -13,7 +13,7 @@ let owner: SignerWithAddress, dataWorker: SignerWithAddress;
 describe("HubPool Relayer Refund", function () {
   before(async function () {
     [owner, dataWorker] = await ethers.getSigners();
-    ({ weth, hubPool, usdc } = await deployHubPoolTestHelperContracts(owner));
+    ({ weth, hubPool, usdc } = await hubPoolFixture());
     await seedWallet(dataWorker, [], weth, bondAmount);
   });
 

--- a/test/SpokePool.Admin.ts
+++ b/test/SpokePool.Admin.ts
@@ -2,7 +2,7 @@ import { expect } from "chai";
 import { Contract } from "ethers";
 import { ethers } from "hardhat";
 import { SignerWithAddress } from "./utils";
-import { deploySpokePoolTestHelperContracts } from "./SpokePool.Fixture";
+import { spokePoolFixture } from "./SpokePool.Fixture";
 import { depositDestinationChainId } from "./constants";
 
 let spokePool: Contract, erc20: Contract;
@@ -11,7 +11,7 @@ let owner: SignerWithAddress;
 describe("SpokePool Admin Functions", async function () {
   beforeEach(async function () {
     [owner] = await ethers.getSigners();
-    ({ spokePool, erc20 } = await deploySpokePoolTestHelperContracts(owner));
+    ({ spokePool, erc20 } = await spokePoolFixture());
   });
   it("Enable token path", async function () {
     await expect(spokePool.connect(owner).setEnableRoute(erc20.address, depositDestinationChainId, true))

--- a/test/SpokePool.Deposit.ts
+++ b/test/SpokePool.Deposit.ts
@@ -2,7 +2,7 @@ import { expect } from "chai";
 import { Contract } from "ethers";
 import { ethers } from "hardhat";
 import { SignerWithAddress, seedWallet, toBN, toWei } from "./utils";
-import { deploySpokePoolTestHelperContracts, enableRoutes } from "./SpokePool.Fixture";
+import { spokePoolFixture, enableRoutes } from "./SpokePool.Fixture";
 import { amountToSeedWallets, amountToDeposit, depositDestinationChainId, depositRelayerFeePct } from "./constants";
 
 let spokePool: Contract, weth: Contract, erc20: Contract, unwhitelistedErc20: Contract;
@@ -11,7 +11,7 @@ let depositor: SignerWithAddress, recipient: SignerWithAddress;
 describe("SpokePool Depositor Logic", async function () {
   beforeEach(async function () {
     [depositor, recipient] = await ethers.getSigners();
-    ({ weth, erc20, spokePool, unwhitelistedErc20 } = await deploySpokePoolTestHelperContracts(depositor));
+    ({ weth, erc20, spokePool, unwhitelistedErc20 } = await spokePoolFixture());
 
     // mint some fresh tokens and deposit ETH for weth for the depositor.
     await seedWallet(depositor, [erc20], weth, amountToSeedWallets);

--- a/test/SpokePool.Fixture.ts
+++ b/test/SpokePool.Fixture.ts
@@ -8,10 +8,12 @@ import {
   depositRelayerFeePct,
   realizedLpFeePct,
 } from "./constants";
+import hre from "hardhat";
 
 const { defaultAbiCoder, keccak256 } = utils;
 
-export async function deploySpokePoolTestHelperContracts(deployerWallet: SignerWithAddress) {
+export const spokePoolFixture = hre.deployments.createFixture(async ({ ethers }) => {
+  const [deployerWallet] = await ethers.getSigners();
   // Useful contracts.
   const timer = await (await getContractFactory("Timer", deployerWallet)).deploy();
 
@@ -34,7 +36,7 @@ export async function deploySpokePoolTestHelperContracts(deployerWallet: SignerW
   ).deploy(weth.address, depositQuoteTimeBuffer, timer.address);
 
   return { timer, weth, erc20, spokePool, unwhitelistedErc20, destErc20 };
-}
+});
 
 export interface DepositRoute {
   originToken: string;

--- a/test/SpokePool.Relay.ts
+++ b/test/SpokePool.Relay.ts
@@ -2,7 +2,7 @@ import { expect } from "chai";
 import { Contract } from "ethers";
 import { ethers } from "hardhat";
 import { SignerWithAddress, seedWallet, toWei, toBN } from "./utils";
-import { deploySpokePoolTestHelperContracts, enableRoutes, getRelayHash } from "./SpokePool.Fixture";
+import { spokePoolFixture, enableRoutes, getRelayHash } from "./SpokePool.Fixture";
 import {
   amountToSeedWallets,
   amountToDeposit,
@@ -21,7 +21,7 @@ let depositor: SignerWithAddress, recipient: SignerWithAddress, relayer: SignerW
 describe("SpokePool Relayer Logic", async function () {
   beforeEach(async function () {
     [depositor, recipient, relayer] = await ethers.getSigners();
-    ({ weth, erc20, spokePool, destErc20 } = await deploySpokePoolTestHelperContracts(depositor));
+    ({ weth, erc20, spokePool, destErc20 } = await spokePoolFixture());
 
     // mint some fresh tokens and deposit ETH for weth for depositor and relayer.
     await seedWallet(depositor, [erc20], weth, amountToSeedWallets);

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -31,7 +31,7 @@ export const fromWei = (num: string | number | BigNumber) => ethers.utils.format
 
 export const toBN = (num: string | number | BigNumber) => {
   // If the string version of the num contains a `.` then it is a number which needs to be parsed to a string int.
-  if (num.toString().includes(".")) return BigNumber.from(parseInt(num as any));
+  if (num.toString().includes(".")) return BigNumber.from(parseInt(num.toString()));
   return BigNumber.from(num.toString());
 };
 


### PR DESCRIPTION
This PR is just a simple refactor that moves the existing test deployment logic to using hardhat fixtures, which is the recommended way to "snapshot" deployments in tests.

I ran an a/b test on these (and ensured that all conditions were the same, like contracts were already compiled, etc). We saw a pretty decent test speedup from 16s to 12s (25%-ish). This is pretty small, and as long as the repo and tests stay simple and small this will be insignificant, but still good to know that it didn't slow things down :).

Note: this also includes one or two `any`s that I saw an opportunity to replace with something more specific.