### PR TITLE
improve: Destructure RelayData params in FilledRelay event

### DIFF
--- a/test/SpokePool.Fixture.ts
+++ b/test/SpokePool.Fixture.ts
@@ -69,34 +69,46 @@ export async function deposit(
       currentSpokePoolTime
     );
 }
+export interface RelayData {
+  depositor: string;
+  recipient: string;
+  destinationToken: string;
+  realizedLpFeePct: string;
+  relayerFeePct: string;
+  depositId: string;
+  originChainId: string;
+  relayAmount: string;
+}
 export function getRelayHash(
-  sender: string,
-  recipient: string,
-  depositId: number,
-  originChainId: number,
-  destinationToken: string,
-  relayAmount?: string,
+  _depositor: string,
+  _recipient: string,
+  _depositId: number,
+  _originChainId: number,
+  _destinationToken: string,
+  _relayAmount?: string,
   _realizedLpFeePct?: string,
-  relayerFeePct?: string
-): { relayHash: string; relayData: string[] } {
-  const relayData = [
-    sender,
-    recipient,
-    destinationToken,
-    _realizedLpFeePct || realizedLpFeePct.toString(),
-    relayerFeePct || depositRelayerFeePct.toString(),
-    depositId.toString(),
-    originChainId.toString(),
-    relayAmount || amountToDeposit.toString(),
-  ];
+  _relayerFeePct?: string
+): { relayHash: string; relayData: RelayData; relayDataValues: string[] } {
+  const relayData = {
+    depositor: _depositor,
+    recipient: _recipient,
+    destinationToken: _destinationToken,
+    realizedLpFeePct: _realizedLpFeePct || realizedLpFeePct.toString(),
+    relayerFeePct: _relayerFeePct || depositRelayerFeePct.toString(),
+    depositId: _depositId.toString(),
+    originChainId: _originChainId.toString(),
+    relayAmount: _relayAmount || amountToDeposit.toString(),
+  };
+  const relayDataValues = Object.values(relayData);
   const relayHash = keccak256(
     defaultAbiCoder.encode(
       ["address", "address", "address", "uint64", "uint64", "uint64", "uint256", "uint256"],
-      relayData
+      relayDataValues
     )
   );
   return {
     relayHash,
     relayData,
+    relayDataValues,
   };
 }

--- a/test/SpokePool.Relay.ts
+++ b/test/SpokePool.Relay.ts
@@ -18,7 +18,7 @@ import {
 let spokePool: Contract, weth: Contract, erc20: Contract, destErc20: Contract;
 let depositor: SignerWithAddress, recipient: SignerWithAddress, relayer: SignerWithAddress;
 
-describe("SpokePool Relayer Logic", async function () {
+describe.only("SpokePool Relayer Logic", async function () {
   beforeEach(async function () {
     [depositor, recipient, relayer] = await ethers.getSigners();
     ({ weth, erc20, spokePool, destErc20 } = await deploySpokePoolTestHelperContracts(depositor));
@@ -58,7 +58,7 @@ describe("SpokePool Relayer Logic", async function () {
         relayHash,
         relayData.relayAmount,
         amountToRelayPreFees,
-        amountToRelay,
+        amountToRelayPreFees,
         repaymentChainId,
         relayData.originChainId,
         relayData.depositId,
@@ -82,14 +82,14 @@ describe("SpokePool Relayer Logic", async function () {
     const fullRelayAmount = amountToDeposit;
     const fullRelayAmountPostFees = fullRelayAmount.mul(totalPostFeesPct).div(toBN(oneHundredPct));
     const amountRemainingInRelay = fullRelayAmount.sub(amountToRelayPreFees);
-    const amountRemainingInRelayPostFees = amountRemainingInRelay.mul(totalPostFeesPct).div(toBN(oneHundredPct));
+    // const amountRemainingInRelayPostFees = amountRemainingInRelay.mul(totalPostFeesPct).div(toBN(oneHundredPct));
     await expect(spokePool.connect(relayer).fillRelay(...relayDataValues, fullRelayAmount, repaymentChainId))
       .to.emit(spokePool, "FilledRelay")
       .withArgs(
         relayHash,
         relayData.relayAmount,
         fullRelayAmount,
-        amountRemainingInRelayPostFees,
+        amountRemainingInRelay,
         repaymentChainId,
         relayData.originChainId,
         relayData.depositId,
@@ -122,7 +122,7 @@ describe("SpokePool Relayer Logic", async function () {
         relayHash,
         relayData.relayAmount,
         amountToRelayPreFees,
-        amountToRelay,
+        amountToRelayPreFees,
         repaymentChainId,
         relayData.originChainId,
         relayData.depositId,

--- a/test/SpokePool.Relay.ts
+++ b/test/SpokePool.Relay.ts
@@ -18,7 +18,7 @@ import {
 let spokePool: Contract, weth: Contract, erc20: Contract, destErc20: Contract;
 let depositor: SignerWithAddress, recipient: SignerWithAddress, relayer: SignerWithAddress;
 
-describe.only("SpokePool Relayer Logic", async function () {
+describe("SpokePool Relayer Logic", async function () {
   beforeEach(async function () {
     [depositor, recipient, relayer] = await ethers.getSigners();
     ({ weth, erc20, spokePool, destErc20 } = await deploySpokePoolTestHelperContracts(depositor));

--- a/test/SpokePool.Relay.ts
+++ b/test/SpokePool.Relay.ts
@@ -44,7 +44,7 @@ describe("SpokePool Relayer Logic", async function () {
     ]);
   });
   it("Relaying ERC20 tokens correctly pulls tokens and changes contract state", async function () {
-    const { relayHash, relayData } = getRelayHash(
+    const { relayHash, relayData, relayDataValues } = getRelayHash(
       depositor.address,
       recipient.address,
       firstDepositId,
@@ -52,9 +52,23 @@ describe("SpokePool Relayer Logic", async function () {
       destErc20.address
     );
 
-    await expect(spokePool.connect(relayer).fillRelay(...relayData, amountToRelay, repaymentChainId))
+    await expect(spokePool.connect(relayer).fillRelay(...relayDataValues, amountToRelay, repaymentChainId))
       .to.emit(spokePool, "FilledRelay")
-      .withArgs(relayHash, amountToRelayPreFees, repaymentChainId, amountToRelay, relayer.address, relayData);
+      .withArgs(
+        relayHash,
+        relayData.relayAmount,
+        amountToRelayPreFees,
+        amountToRelay,
+        repaymentChainId,
+        relayData.originChainId,
+        relayData.depositId,
+        relayData.relayerFeePct,
+        relayData.realizedLpFeePct,
+        relayData.destinationToken,
+        relayer.address,
+        relayData.depositor,
+        relayData.recipient
+      );
 
     // The collateral should have transferred from relayer to recipient.
     expect(await destErc20.balanceOf(relayer.address)).to.equal(amountToSeedWallets.sub(amountToRelay));
@@ -69,15 +83,22 @@ describe("SpokePool Relayer Logic", async function () {
     const fullRelayAmountPostFees = fullRelayAmount.mul(totalPostFeesPct).div(toBN(oneHundredPct));
     const amountRemainingInRelay = fullRelayAmount.sub(amountToRelayPreFees);
     const amountRemainingInRelayPostFees = amountRemainingInRelay.mul(totalPostFeesPct).div(toBN(oneHundredPct));
-    await expect(spokePool.connect(relayer).fillRelay(...relayData, fullRelayAmount, repaymentChainId))
+    await expect(spokePool.connect(relayer).fillRelay(...relayDataValues, fullRelayAmount, repaymentChainId))
       .to.emit(spokePool, "FilledRelay")
       .withArgs(
         relayHash,
+        relayData.relayAmount,
         fullRelayAmount,
-        repaymentChainId,
         amountRemainingInRelayPostFees,
+        repaymentChainId,
+        relayData.originChainId,
+        relayData.depositId,
+        relayData.relayerFeePct,
+        relayData.realizedLpFeePct,
+        relayData.destinationToken,
         relayer.address,
-        relayData
+        relayData.depositor,
+        relayData.recipient
       );
     expect(await destErc20.balanceOf(relayer.address)).to.equal(amountToSeedWallets.sub(fullRelayAmountPostFees));
     expect(await destErc20.balanceOf(recipient.address)).to.equal(fullRelayAmountPostFees);
@@ -86,7 +107,7 @@ describe("SpokePool Relayer Logic", async function () {
     expect(await spokePool.relayFills(relayHash)).to.equal(fullRelayAmount);
   });
   it("Relaying WETH correctly unwraps into ETH", async function () {
-    const { relayHash, relayData } = getRelayHash(
+    const { relayHash, relayData, relayDataValues } = getRelayHash(
       depositor.address,
       recipient.address,
       firstDepositId,
@@ -95,9 +116,23 @@ describe("SpokePool Relayer Logic", async function () {
     );
 
     const startingRecipientBalance = await recipient.getBalance();
-    await expect(spokePool.connect(relayer).fillRelay(...relayData, amountToRelay, repaymentChainId))
+    await expect(spokePool.connect(relayer).fillRelay(...relayDataValues, amountToRelay, repaymentChainId))
       .to.emit(spokePool, "FilledRelay")
-      .withArgs(relayHash, amountToRelayPreFees, repaymentChainId, amountToRelay, relayer.address, relayData);
+      .withArgs(
+        relayHash,
+        relayData.relayAmount,
+        amountToRelayPreFees,
+        amountToRelay,
+        repaymentChainId,
+        relayData.originChainId,
+        relayData.depositId,
+        relayData.relayerFeePct,
+        relayData.realizedLpFeePct,
+        relayData.destinationToken,
+        relayer.address,
+        relayData.depositor,
+        relayData.recipient
+      );
 
     // The collateral should have unwrapped to ETH and then transferred to recipient.
     expect(await weth.balanceOf(relayer.address)).to.equal(amountToSeedWallets.sub(amountToRelay));
@@ -121,7 +156,7 @@ describe("SpokePool Relayer Logic", async function () {
             amountToDeposit.toString(),
             toWei("0.51").toString(),
             toWei("0.5").toString()
-          ).relayData,
+          ).relayDataValues,
           amountToRelay,
           repaymentChainId
         )
@@ -139,7 +174,7 @@ describe("SpokePool Relayer Logic", async function () {
             amountToDeposit.toString(),
             toWei("0.5").toString(),
             toWei("0.51").toString()
-          ).relayData,
+          ).relayDataValues,
           amountToRelay,
           repaymentChainId
         )
@@ -157,7 +192,7 @@ describe("SpokePool Relayer Logic", async function () {
             amountToDeposit.toString(),
             toWei("0.5").toString(),
             toWei("0.5").toString()
-          ).relayData,
+          ).relayDataValues,
           amountToRelay,
           repaymentChainId
         )
@@ -169,7 +204,7 @@ describe("SpokePool Relayer Logic", async function () {
         .connect(relayer)
         .fillRelay(
           ...getRelayHash(depositor.address, recipient.address, firstDepositId, originChainId, destErc20.address)
-            .relayData,
+            .relayDataValues,
           "0",
           repaymentChainId
         )
@@ -177,7 +212,8 @@ describe("SpokePool Relayer Logic", async function () {
 
     // Relay already filled
     await spokePool.connect(relayer).fillRelay(
-      ...getRelayHash(depositor.address, recipient.address, firstDepositId, originChainId, destErc20.address).relayData,
+      ...getRelayHash(depositor.address, recipient.address, firstDepositId, originChainId, destErc20.address)
+        .relayDataValues,
       amountToDeposit, // Send the full relay amount
       repaymentChainId
     );
@@ -186,7 +222,7 @@ describe("SpokePool Relayer Logic", async function () {
         .connect(relayer)
         .fillRelay(
           ...getRelayHash(depositor.address, recipient.address, firstDepositId, originChainId, destErc20.address)
-            .relayData,
+            .relayDataValues,
           "1",
           repaymentChainId
         )


### PR DESCRIPTION
In the past, emitting a complex object in an event causes Etherscan difficulty in decoding the params. We should emit all neccessary params individually.