### PR TITLE
feat(spoke-pool): Reduce size of state variables

### DIFF
--- a/contracts/Optimism_SpokePool.sol
+++ b/contracts/Optimism_SpokePool.sol
@@ -23,11 +23,11 @@ contract Optimism_SpokePool is CrossDomainEnabled, SpokePoolInterface, SpokePool
         address _crossDomainAdmin,
         address _hubPool,
         address _wethAddress,
-        uint64 _depositQuoteTimeBuffer,
-        address timerAddress
+        address timerAddress,
+        uint32 _depositQuoteTimeBuffer
     )
         CrossDomainEnabled(Lib_PredeployAddresses.L2_CROSS_DOMAIN_MESSENGER)
-        SpokePool(_crossDomainAdmin, _hubPool, _wethAddress, _depositQuoteTimeBuffer, timerAddress)
+        SpokePool(_crossDomainAdmin, _hubPool, _wethAddress, timerAddress, _depositQuoteTimeBuffer)
     {}
 
     /**************************************
@@ -63,13 +63,13 @@ contract Optimism_SpokePool is CrossDomainEnabled, SpokePoolInterface, SpokePool
 
     function setEnableRoute(
         address originToken,
-        uint256 destinationChainId,
+        uint32 destinationChainId,
         bool enable
     ) public override onlyFromCrossDomainAccount(crossDomainAdmin) nonReentrant {
         _setEnableRoute(originToken, destinationChainId, enable);
     }
 
-    function setDepositQuoteTimeBuffer(uint64 buffer)
+    function setDepositQuoteTimeBuffer(uint32 buffer)
         public
         override
         onlyFromCrossDomainAccount(crossDomainAdmin)

--- a/contracts/Optimism_SpokePool.sol
+++ b/contracts/Optimism_SpokePool.sol
@@ -23,11 +23,10 @@ contract Optimism_SpokePool is CrossDomainEnabled, SpokePoolInterface, SpokePool
         address _crossDomainAdmin,
         address _hubPool,
         address _wethAddress,
-        address timerAddress,
-        uint32 _depositQuoteTimeBuffer
+        address timerAddress
     )
         CrossDomainEnabled(Lib_PredeployAddresses.L2_CROSS_DOMAIN_MESSENGER)
-        SpokePool(_crossDomainAdmin, _hubPool, _wethAddress, timerAddress, _depositQuoteTimeBuffer)
+        SpokePool(_crossDomainAdmin, _hubPool, _wethAddress, timerAddress)
     {}
 
     /**************************************

--- a/contracts/SpokePool.sol
+++ b/contracts/SpokePool.sol
@@ -41,6 +41,10 @@ abstract contract SpokePool is SpokePoolInterface, Testable, Lockable, MultiCall
     // Address of the L1 contract that will send tokens to and receive tokens from this contract.
     address public hubPool;
 
+    // Address of WETH contract for this network. If an origin token matches this, then the caller can optionally
+    // instruct this contract to wrap ETH when depositing.
+    WETH9 public weth;
+
     // Timestamp when contract was constructed. Relays cannot have a quote time before this.
     uint32 public deploymentTime;
 
@@ -50,10 +54,6 @@ abstract contract SpokePool is SpokePoolInterface, Testable, Lockable, MultiCall
 
     // Use count of deposits as unique deposit identifier.
     uint32 public numberOfDeposits;
-
-    // Address of WETH contract for this network. If an origin token matches this, then the caller can optionally
-    // instruct this contract to wrap ETH when depositing.
-    WETH9 public weth;
 
     // Origin token to destination token routings can be turned on or off.
     mapping(address => mapping(uint32 => bool)) public enabledDepositRoutes;

--- a/contracts/SpokePool.sol
+++ b/contracts/SpokePool.sol
@@ -45,8 +45,8 @@ abstract contract SpokePool is SpokePoolInterface, Testable, Lockable, MultiCall
     uint32 public deploymentTime;
 
     // Any deposit quote times greater than or less than this value to the current contract time is blocked. Forces
-    // caller to use an up to date realized fee.
-    uint32 public depositQuoteTimeBuffer;
+    // caller to use an up to date realized fee. Defaults to 10 minutes.
+    uint32 public depositQuoteTimeBuffer = 600;
 
     // Use count of deposits as unique deposit identifier.
     uint32 public numberOfDeposits;
@@ -147,13 +147,11 @@ abstract contract SpokePool is SpokePoolInterface, Testable, Lockable, MultiCall
         address _crossDomainAdmin,
         address _hubPool,
         address _wethAddress,
-        address timerAddress,
-        uint32 _depositQuoteTimeBuffer
+        address timerAddress
     ) Testable(timerAddress) {
         _setCrossDomainAdmin(_crossDomainAdmin);
         _setHubPool(_hubPool);
         deploymentTime = uint32(getCurrentTime());
-        depositQuoteTimeBuffer = _depositQuoteTimeBuffer;
         weth = WETH9(_wethAddress);
     }
 

--- a/contracts/SpokePool.sol
+++ b/contracts/SpokePool.sol
@@ -42,21 +42,21 @@ abstract contract SpokePool is SpokePoolInterface, Testable, Lockable, MultiCall
     address public hubPool;
 
     // Timestamp when contract was constructed. Relays cannot have a quote time before this.
-    uint64 public deploymentTime;
+    uint32 public deploymentTime;
 
     // Any deposit quote times greater than or less than this value to the current contract time is blocked. Forces
     // caller to use an up to date realized fee.
-    uint64 public depositQuoteTimeBuffer;
+    uint32 public depositQuoteTimeBuffer;
 
     // Use count of deposits as unique deposit identifier.
-    uint64 public numberOfDeposits;
+    uint32 public numberOfDeposits;
 
     // Address of WETH contract for this network. If an origin token matches this, then the caller can optionally
     // instruct this contract to wrap ETH when depositing.
     WETH9 public weth;
 
     // Origin token to destination token routings can be turned on or off.
-    mapping(address => mapping(uint256 => bool)) public enabledDepositRoutes;
+    mapping(address => mapping(uint32 => bool)) public enabledDepositRoutes;
 
     struct RelayerRefund {
         // Merkle root of slow relays that were not fully filled and whose recipient is still owed funds from the LP pool.
@@ -79,14 +79,14 @@ abstract contract SpokePool is SpokePoolInterface, Testable, Lockable, MultiCall
      ****************************************/
     event SetXDomainAdmin(address indexed newAdmin);
     event SetHubPool(address indexed newHubPool);
-    event EnabledDepositRoute(address indexed originToken, uint256 indexed destinationChainId, bool enabled);
-    event SetDepositQuoteTimeBuffer(uint64 newBuffer);
+    event EnabledDepositRoute(address indexed originToken, uint32 indexed destinationChainId, bool enabled);
+    event SetDepositQuoteTimeBuffer(uint32 newBuffer);
     event FundsDeposited(
-        uint256 destinationChainId,
         uint256 amount,
-        uint64 indexed depositId,
         uint64 relayerFeePct,
-        uint64 quoteTimestamp,
+        uint32 destinationChainId,
+        uint32 indexed depositId,
+        uint32 quoteTimestamp,
         address indexed originToken,
         address recipient,
         address indexed depositor
@@ -96,11 +96,11 @@ abstract contract SpokePool is SpokePoolInterface, Testable, Lockable, MultiCall
         uint256 totalRelayAmount,
         uint256 totalFilledAmount,
         uint256 fillAmount,
-        uint256 indexed repaymentChain,
-        uint256 originChainId,
-        uint64 depositId,
         uint64 relayerFeePct,
         uint64 realizedLpFeePct,
+        uint32 indexed repaymentChain,
+        uint32 originChainId,
+        uint32 depositId,
         address destinationToken,
         address indexed relayer,
         address depositor,
@@ -111,34 +111,34 @@ abstract contract SpokePool is SpokePoolInterface, Testable, Lockable, MultiCall
         uint256 totalRelayAmount,
         uint256 totalFilledAmount,
         uint256 fillAmount,
-        uint256 originChainId,
-        uint64 depositId,
         uint64 relayerFeePct,
         uint64 realizedLpFeePct,
+        uint32 originChainId,
+        uint32 depositId,
         address destinationToken,
         address indexed caller,
         address depositor,
         address recipient
     );
     event InitializedRelayerRefund(
-        uint256 indexed relayerRefundId,
+        uint32 indexed relayerRefundId,
         bytes32 relayerRepaymentDistributionRoot,
         bytes32 slowRelayFulfillmentRoot
     );
     event DistributedRelayerRefund(
-        uint256 indexed relayerRefundId,
-        uint256 indexed leafId,
-        uint256 chainId,
         uint256 amountToReturn,
         uint256[] refundAmounts,
+        uint32 indexed relayerRefundId,
+        uint32 indexed leafId,
+        uint32 chainId,
         address l2TokenAddress,
         address[] refundAddresses,
         address indexed caller
     );
     event TokensBridged(
-        uint256 indexed leafId,
-        uint256 indexed chainId,
         uint256 amountToReturn,
+        uint32 indexed leafId,
+        uint32 indexed chainId,
         address indexed l2TokenAddress,
         address caller
     );
@@ -147,12 +147,12 @@ abstract contract SpokePool is SpokePoolInterface, Testable, Lockable, MultiCall
         address _crossDomainAdmin,
         address _hubPool,
         address _wethAddress,
-        uint64 _depositQuoteTimeBuffer,
-        address timerAddress
+        address timerAddress,
+        uint32 _depositQuoteTimeBuffer
     ) Testable(timerAddress) {
         _setCrossDomainAdmin(_crossDomainAdmin);
         _setHubPool(_hubPool);
-        deploymentTime = uint64(getCurrentTime());
+        deploymentTime = uint32(getCurrentTime());
         depositQuoteTimeBuffer = _depositQuoteTimeBuffer;
         weth = WETH9(_wethAddress);
     }
@@ -161,7 +161,7 @@ abstract contract SpokePool is SpokePoolInterface, Testable, Lockable, MultiCall
      *               MODIFIERS              *
      ****************************************/
 
-    modifier onlyEnabledRoute(address originToken, uint256 destinationId) {
+    modifier onlyEnabledRoute(address originToken, uint32 destinationId) {
         require(enabledDepositRoutes[originToken][destinationId], "Disabled route");
         _;
     }
@@ -184,14 +184,14 @@ abstract contract SpokePool is SpokePoolInterface, Testable, Lockable, MultiCall
 
     function _setEnableRoute(
         address originToken,
-        uint256 destinationChainId,
+        uint32 destinationChainId,
         bool enabled
     ) internal {
         enabledDepositRoutes[originToken][destinationChainId] = enabled;
         emit EnabledDepositRoute(originToken, destinationChainId, enabled);
     }
 
-    function _setDepositQuoteTimeBuffer(uint64 _depositQuoteTimeBuffer) internal {
+    function _setDepositQuoteTimeBuffer(uint32 _depositQuoteTimeBuffer) internal {
         depositQuoteTimeBuffer = _depositQuoteTimeBuffer;
         emit SetDepositQuoteTimeBuffer(_depositQuoteTimeBuffer);
     }
@@ -205,12 +205,12 @@ abstract contract SpokePool is SpokePoolInterface, Testable, Lockable, MultiCall
      * @dev The caller must first approve this contract to spend `amount` of `originToken`.
      */
     function deposit(
-        address originToken,
-        uint256 destinationChainId,
-        uint256 amount,
         address recipient,
+        address originToken,
+        uint256 amount,
         uint64 relayerFeePct,
-        uint64 quoteTimestamp
+        uint32 destinationChainId,
+        uint32 quoteTimestamp
     ) public payable onlyEnabledRoute(originToken, destinationChainId) nonReentrant {
         // We limit the relay fees to prevent the user spending all their funds on fees.
         require(relayerFeePct <= 0.5e18, "invalid relayer fee");
@@ -237,10 +237,10 @@ abstract contract SpokePool is SpokePoolInterface, Testable, Lockable, MultiCall
         }
 
         emit FundsDeposited(
-            destinationChainId,
             amount,
-            numberOfDeposits,
             relayerFeePct,
+            destinationChainId,
+            numberOfDeposits,
             quoteTimestamp,
             originToken,
             recipient,
@@ -258,13 +258,13 @@ abstract contract SpokePool is SpokePoolInterface, Testable, Lockable, MultiCall
         address depositor,
         address recipient,
         address destinationToken,
-        uint64 realizedLpFeePct,
-        uint64 relayerFeePct,
-        uint64 depositId,
-        uint256 originChainId,
         uint256 totalRelayAmount,
         uint256 maxTokensToSend,
-        uint256 repaymentChain
+        uint64 realizedLpFeePct,
+        uint64 relayerFeePct,
+        uint32 repaymentChain,
+        uint32 depositId,
+        uint32 originChainId
     ) public nonReentrant {
         // Each relay attempt is mapped to the hash of data uniquely identifying it, which includes the deposit data
         // such as the origin chain ID and the deposit ID, and the data in a relay attempt such as who the recipient
@@ -273,33 +273,31 @@ abstract contract SpokePool is SpokePoolInterface, Testable, Lockable, MultiCall
             depositor: depositor,
             recipient: recipient,
             destinationToken: destinationToken,
+            relayAmount: totalRelayAmount,
             realizedLpFeePct: realizedLpFeePct,
             relayerFeePct: relayerFeePct,
             depositId: depositId,
-            originChainId: originChainId,
-            relayAmount: totalRelayAmount
+            originChainId: originChainId
         });
         bytes32 relayHash = _getRelayHash(relayData);
 
-        uint256 fillAmountPreFees = _fillRelay(relayHash, relayData, relayerFeePct, maxTokensToSend, false);
+        uint256 fillAmountPreFees = _fillRelay(relayHash, relayData, maxTokensToSend, relayerFeePct, false);
 
-        _emitFillRelay(relayHash, fillAmountPreFees, repaymentChain, relayerFeePct, relayData);
+        _emitFillRelay(relayHash, fillAmountPreFees, relayerFeePct, repaymentChain, relayData);
     }
 
-    // We overload `fillRelay` logic to allow the relayer to optionally pass in an updated `relayerFeePct` and a signature
-    // proving that the depositor agreed to the updated fee.
     function fillRelayWithUpdatedFee(
         address depositor,
         address recipient,
         address destinationToken,
+        uint256 totalRelayAmount,
+        uint256 maxTokensToSend,
         uint64 realizedLpFeePct,
         uint64 relayerFeePct,
         uint64 newRelayerFeePct,
-        uint64 depositId,
-        uint256 originChainId,
-        uint256 totalRelayAmount,
-        uint256 maxTokensToSend,
-        uint256 repaymentChain,
+        uint32 repaymentChain,
+        uint32 depositId,
+        uint32 originChainId,
         bytes memory depositorSignature
     ) public nonReentrant {
         // Grouping the signature validation logic into brackets to address stack too deep error.
@@ -335,39 +333,39 @@ abstract contract SpokePool is SpokePoolInterface, Testable, Lockable, MultiCall
             depositor: depositor,
             recipient: recipient,
             destinationToken: destinationToken,
+            relayAmount: totalRelayAmount,
             realizedLpFeePct: realizedLpFeePct,
             relayerFeePct: relayerFeePct,
             depositId: depositId,
-            originChainId: originChainId,
-            relayAmount: totalRelayAmount
+            originChainId: originChainId
         });
         bytes32 relayHash = _getRelayHash(relayData);
-        uint256 fillAmountPreFees = _fillRelay(relayHash, relayData, newRelayerFeePct, maxTokensToSend, false);
+        uint256 fillAmountPreFees = _fillRelay(relayHash, relayData, maxTokensToSend, newRelayerFeePct, false);
 
-        _emitFillRelay(relayHash, fillAmountPreFees, repaymentChain, newRelayerFeePct, relayData);
+        _emitFillRelay(relayHash, fillAmountPreFees, newRelayerFeePct, repaymentChain, relayData);
     }
 
     function distributeRelaySlow(
         address depositor,
         address recipient,
         address destinationToken,
+        uint256 totalRelayAmount,
         uint64 realizedLpFeePct,
         uint64 relayerFeePct,
-        uint64 depositId,
-        uint256 originChainId,
-        uint256 totalRelayAmount,
-        uint256 relayerRefundId,
+        uint32 depositId,
+        uint32 originChainId,
+        uint32 relayerRefundId,
         bytes32[] memory proof
     ) public nonReentrant {
         RelayData memory relayData = RelayData({
             depositor: depositor,
             recipient: recipient,
             destinationToken: destinationToken,
+            relayAmount: totalRelayAmount,
             realizedLpFeePct: realizedLpFeePct,
             relayerFeePct: relayerFeePct,
             depositId: depositId,
-            originChainId: originChainId,
-            relayAmount: totalRelayAmount
+            originChainId: originChainId
         });
 
         require(
@@ -383,7 +381,7 @@ abstract contract SpokePool is SpokePoolInterface, Testable, Lockable, MultiCall
 
         // Note: use relayAmount as the max amount to send, so the relay is always completely filled by the contract's
         // funds in all cases.
-        uint256 fillAmountPreFees = _fillRelay(relayHash, relayData, relayerFeePct, relayData.relayAmount, true);
+        uint256 fillAmountPreFees = _fillRelay(relayHash, relayData, relayData.relayAmount, relayerFeePct, true);
 
         _emitDistributeRelaySlow(relayHash, fillAmountPreFees, relayData);
     }
@@ -395,7 +393,7 @@ abstract contract SpokePool is SpokePoolInterface, Testable, Lockable, MultiCall
     // valid `inclusionProof` to verify that the leaf is contained within the root. The `relayerRefundId` is the index
     // of the specific distribution root containing the passed in leaf.
     function distributeRelayerRefund(
-        uint256 relayerRefundId,
+        uint32 relayerRefundId,
         SpokePoolInterface.DestinationDistributionLeaf memory distributionLeaf,
         bytes32[] memory proof
     ) public override nonReentrant {
@@ -427,24 +425,23 @@ abstract contract SpokePool is SpokePoolInterface, Testable, Lockable, MultiCall
         // If `distributionLeaf.amountToReturn` is positive, then send L2 --> L1 message to bridge tokens back via
         // chain-specific bridging method.
         if (distributionLeaf.amountToReturn > 0) {
-            // Do we need to perform any check about the last time that funds were bridged from L2 to L1?
             _bridgeTokensToHubPool(distributionLeaf);
 
             emit TokensBridged(
+                distributionLeaf.amountToReturn,
                 distributionLeaf.leafId,
                 distributionLeaf.chainId,
-                distributionLeaf.amountToReturn,
                 distributionLeaf.l2TokenAddress,
                 msg.sender
             );
         }
 
         emit DistributedRelayerRefund(
+            distributionLeaf.amountToReturn,
+            distributionLeaf.refundAmounts,
             relayerRefundId,
             distributionLeaf.leafId,
             distributionLeaf.chainId,
-            distributionLeaf.amountToReturn,
-            distributionLeaf.refundAmounts,
             distributionLeaf.l2TokenAddress,
             distributionLeaf.refundAddresses,
             msg.sender
@@ -467,11 +464,11 @@ abstract contract SpokePool is SpokePoolInterface, Testable, Lockable, MultiCall
         internal
         virtual;
 
-    function _computeAmountPreFees(uint256 amount, uint256 feesPct) private pure returns (uint256) {
+    function _computeAmountPreFees(uint256 amount, uint64 feesPct) private pure returns (uint256) {
         return (1e18 * amount) / (1e18 - feesPct);
     }
 
-    function _computeAmountPostFees(uint256 amount, uint256 feesPct) private pure returns (uint256) {
+    function _computeAmountPostFees(uint256 amount, uint64 feesPct) private pure returns (uint256) {
         return (amount * (1e18 - feesPct)) / 1e18;
     }
 
@@ -498,7 +495,7 @@ abstract contract SpokePool is SpokePoolInterface, Testable, Lockable, MultiCall
     function _initializeRelayerRefund(bytes32 relayerRepaymentDistributionRoot, bytes32 slowRelayFulfillmentRoot)
         internal
     {
-        uint256 relayerRefundId = relayerRefunds.length;
+        uint32 relayerRefundId = uint32(relayerRefunds.length);
         RelayerRefund storage relayerRefund = relayerRefunds.push();
         relayerRefund.distributionRoot = relayerRepaymentDistributionRoot;
         relayerRefund.slowRelayFulfillmentRoot = slowRelayFulfillmentRoot;
@@ -508,8 +505,8 @@ abstract contract SpokePool is SpokePoolInterface, Testable, Lockable, MultiCall
     function _fillRelay(
         bytes32 relayHash,
         RelayData memory relayData,
-        uint64 updatableRelayerFeePct,
         uint256 maxTokensToSend,
+        uint64 updatableRelayerFeePct,
         bool isSlowRelay
     ) internal returns (uint256 fillAmountPreFees) {
         // We limit the relay fees to prevent the user spending all their funds on fees. Note that 0.5e18 (i.e. 50%)
@@ -560,8 +557,8 @@ abstract contract SpokePool is SpokePoolInterface, Testable, Lockable, MultiCall
     function _emitFillRelay(
         bytes32 relayHash,
         uint256 fillAmount,
-        uint256 repaymentChain,
         uint64 relayerFeePct,
+        uint32 repaymentChain,
         RelayData memory relayData
     ) internal {
         emit FilledRelay(
@@ -569,11 +566,11 @@ abstract contract SpokePool is SpokePoolInterface, Testable, Lockable, MultiCall
             relayData.relayAmount,
             relayFills[relayHash],
             fillAmount,
+            relayerFeePct,
+            relayData.realizedLpFeePct,
             repaymentChain,
             relayData.originChainId,
             relayData.depositId,
-            relayerFeePct,
-            relayData.realizedLpFeePct,
             relayData.destinationToken,
             msg.sender,
             relayData.depositor,
@@ -591,10 +588,10 @@ abstract contract SpokePool is SpokePoolInterface, Testable, Lockable, MultiCall
             relayData.relayAmount,
             relayFills[relayHash],
             fillAmount,
-            relayData.originChainId,
-            relayData.depositId,
             relayData.relayerFeePct,
             relayData.realizedLpFeePct,
+            relayData.originChainId,
+            relayData.depositId,
             relayData.destinationToken,
             msg.sender,
             relayData.depositor,

--- a/contracts/SpokePoolInterface.sol
+++ b/contracts/SpokePoolInterface.sol
@@ -4,20 +4,20 @@ pragma solidity ^0.8.0;
 interface SpokePoolInterface {
     // This leaf is meant to be decoded in the SpokePool in order to pay out individual relayers for this bundle.
     struct DestinationDistributionLeaf {
-        // Used as the index in the bitmap to track whether this leaf has been executed or not.
-        uint256 leafId;
-        // Used to verify that this is being decoded on the correct chainId.
-        uint256 chainId;
         // This is the amount to return to the HubPool. This occurs when there is a PoolRebalanceLeaf netSendAmount that is
         // negative. This is just that value inverted.
         uint256 amountToReturn;
+        // This array designates how much each of those addresses should be refunded.
+        uint256[] refundAmounts;
+        // Used as the index in the bitmap to track whether this leaf has been executed or not.
+        uint32 leafId;
+        // Used to verify that this is being decoded on the correct chainId.
+        uint32 chainId;
         // The associated L2TokenAddress that these claims apply to.
         address l2TokenAddress;
         // These two arrays must be the same length and are parallel arrays. They should be order by refundAddresses.
         // This array designates each address that must be refunded.
         address[] refundAddresses;
-        // This array designates how much each of those addresses should be refunded.
-        uint256[] refundAmounts;
     }
 
     // This struct represents the data to fully-specify a relay. If any portion of this data differs, the relay is
@@ -30,17 +30,17 @@ interface SpokePoolInterface {
         address recipient;
         // The corresponding token address on the destination chain.
         address destinationToken;
+        // The total relay amount before fees are taken out.
+        uint256 relayAmount;
         // The LP Fee percentage computed by the relayer based on the deposit's quote timestamp
         // and the HubPool's utilization.
         uint64 realizedLpFeePct;
         // The relayer fee percentage specified in the deposit.
         uint64 relayerFeePct;
         // The id uniquely identifying this deposit on the origin chain.
-        uint64 depositId;
+        uint32 depositId;
         // Origin chain id.
-        uint256 originChainId;
-        // The total relay amount before fees are taken out.
-        uint256 relayAmount;
+        uint32 originChainId;
     }
 
     function setCrossDomainAdmin(address newCrossDomainAdmin) external;
@@ -49,16 +49,16 @@ interface SpokePoolInterface {
 
     function setEnableRoute(
         address originToken,
-        uint256 destinationChainId,
+        uint32 destinationChainId,
         bool enable
     ) external;
 
-    function setDepositQuoteTimeBuffer(uint64 buffer) external;
+    function setDepositQuoteTimeBuffer(uint32 buffer) external;
 
     function initializeRelayerRefund(bytes32 relayerRepaymentDistributionRoot, bytes32 slowRelayRoot) external;
 
     function distributeRelayerRefund(
-        uint256 relayerRefundId,
+        uint32 relayerRefundId,
         DestinationDistributionLeaf memory distributionLeaf,
         bytes32[] memory inclusionProof
     ) external;

--- a/contracts/test/MockSpokePool.sol
+++ b/contracts/test/MockSpokePool.sol
@@ -13,9 +13,8 @@ contract MockSpokePool is SpokePoolInterface, SpokePool {
         address _crossDomainAdmin,
         address _hubPool,
         address _wethAddress,
-        address timerAddress,
-        uint32 _depositQuoteTimeBuffer
-    ) SpokePool(_crossDomainAdmin, _hubPool, _wethAddress, timerAddress, _depositQuoteTimeBuffer) {}
+        address timerAddress
+    ) SpokePool(_crossDomainAdmin, _hubPool, _wethAddress, timerAddress) {}
 
     function setCrossDomainAdmin(address newCrossDomainAdmin) public override {
         _setCrossDomainAdmin(newCrossDomainAdmin);

--- a/contracts/test/MockSpokePool.sol
+++ b/contracts/test/MockSpokePool.sol
@@ -13,9 +13,9 @@ contract MockSpokePool is SpokePoolInterface, SpokePool {
         address _crossDomainAdmin,
         address _hubPool,
         address _wethAddress,
-        uint64 _depositQuoteTimeBuffer,
-        address timerAddress
-    ) SpokePool(_crossDomainAdmin, _hubPool, _wethAddress, _depositQuoteTimeBuffer, timerAddress) {}
+        address timerAddress,
+        uint32 _depositQuoteTimeBuffer
+    ) SpokePool(_crossDomainAdmin, _hubPool, _wethAddress, timerAddress, _depositQuoteTimeBuffer) {}
 
     function setCrossDomainAdmin(address newCrossDomainAdmin) public override {
         _setCrossDomainAdmin(newCrossDomainAdmin);
@@ -27,13 +27,13 @@ contract MockSpokePool is SpokePoolInterface, SpokePool {
 
     function setEnableRoute(
         address originToken,
-        uint256 destinationChainId,
+        uint32 destinationChainId,
         bool enable
     ) public override {
         _setEnableRoute(originToken, destinationChainId, enable);
     }
 
-    function setDepositQuoteTimeBuffer(uint64 buffer) public override {
+    function setDepositQuoteTimeBuffer(uint32 buffer) public override {
         _setDepositQuoteTimeBuffer(buffer);
     }
 

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -1,6 +1,6 @@
 import * as dotenv from "dotenv";
 
-import { HardhatUserConfig, task } from "hardhat/config";
+import { HardhatUserConfig } from "hardhat/config";
 import "@nomiclabs/hardhat-etherscan";
 import "@nomiclabs/hardhat-waffle";
 import "@typechain/hardhat";

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint": "yarn prettier --list-different",
     "lint-fix": "yarn prettier --write",
     "prettier": "prettier .",
-    "test": "yarn hardhat test"
+    "test": "REPORT_GAS=true yarn hardhat test"
   },
   "dependencies": {
     "@defi-wonderland/smock": "^2.0.7",

--- a/test/HubPool.Fixture.ts
+++ b/test/HubPool.Fixture.ts
@@ -42,7 +42,7 @@ export const hubPoolFixture = hre.deployments.createFixture(async ({ ethers }) =
   const mockAdapter = await (await getContractFactory("Mock_Adapter", signer)).deploy(hubPool.address);
   const mockSpoke = await (
     await getContractFactory("MockSpokePool", { signer: signer, libraries: { MerkleLib: merkleLib.address } })
-  ).deploy(crossChainAdmin.address, hubPool.address, weth.address, 0, parentFixtureOutput.timer.address);
+  ).deploy(crossChainAdmin.address, hubPool.address, weth.address, parentFixtureOutput.timer.address, 0);
   await hubPool.setCrossChainContracts(repaymentChainId, mockAdapter.address, mockSpoke.address);
 
   // Deploy mock l2 tokens for each token created before and whitelist the routes.

--- a/test/HubPool.Fixture.ts
+++ b/test/HubPool.Fixture.ts
@@ -42,7 +42,7 @@ export const hubPoolFixture = hre.deployments.createFixture(async ({ ethers }) =
   const mockAdapter = await (await getContractFactory("Mock_Adapter", signer)).deploy(hubPool.address);
   const mockSpoke = await (
     await getContractFactory("MockSpokePool", { signer: signer, libraries: { MerkleLib: merkleLib.address } })
-  ).deploy(crossChainAdmin.address, hubPool.address, weth.address, parentFixtureOutput.timer.address, 0);
+  ).deploy(crossChainAdmin.address, hubPool.address, weth.address, parentFixtureOutput.timer.address);
   await hubPool.setCrossChainContracts(repaymentChainId, mockAdapter.address, mockSpoke.address);
 
   // Deploy mock l2 tokens for each token created before and whitelist the routes.

--- a/test/MerkleLib.Proofs.ts
+++ b/test/MerkleLib.Proofs.ts
@@ -64,7 +64,7 @@ describe("MerkleLib Proofs", async function () {
       }
       destinationDistributionLeafs.push({
         leafId: BigNumber.from(i),
-        chainId: randomBigNumber(),
+        chainId: randomBigNumber(2),
         amountToReturn: randomBigNumber(),
         l2TokenAddress: randomAddress(),
         refundAddresses,

--- a/test/SpokePool.Deposit.ts
+++ b/test/SpokePool.Deposit.ts
@@ -33,20 +33,20 @@ describe("SpokePool Depositor Logic", async function () {
       spokePool
         .connect(depositor)
         .deposit(
-          erc20.address,
-          destinationChainId,
-          amountToDeposit,
           recipient.address,
+          erc20.address,
+          amountToDeposit,
           depositRelayerFeePct,
+          destinationChainId,
           currentSpokePoolTime
         )
     )
       .to.emit(spokePool, "FundsDeposited")
       .withArgs(
-        destinationChainId,
         amountToDeposit,
-        0,
         depositRelayerFeePct,
+        destinationChainId,
+        0,
         currentSpokePoolTime,
         erc20.address,
         recipient.address,
@@ -68,11 +68,11 @@ describe("SpokePool Depositor Logic", async function () {
       spokePool
         .connect(depositor)
         .deposit(
-          weth.address,
-          destinationChainId,
-          amountToDeposit,
           recipient.address,
+          weth.address,
+          amountToDeposit,
           depositRelayerFeePct,
+          destinationChainId,
           currentSpokePoolTime,
           { value: 1 }
         )
@@ -82,11 +82,11 @@ describe("SpokePool Depositor Logic", async function () {
       spokePool
         .connect(depositor)
         .deposit(
-          weth.address,
-          destinationChainId,
-          amountToDeposit,
           recipient.address,
+          weth.address,
+          amountToDeposit,
           depositRelayerFeePct,
+          destinationChainId,
           currentSpokePoolTime,
           { value: amountToDeposit }
         )
@@ -102,11 +102,11 @@ describe("SpokePool Depositor Logic", async function () {
       spokePool
         .connect(depositor)
         .deposit(
-          weth.address,
-          destinationChainId,
-          amountToDeposit,
           recipient.address,
+          weth.address,
+          amountToDeposit,
           depositRelayerFeePct,
+          destinationChainId,
           currentSpokePoolTime,
           { value: 0 }
         )
@@ -121,11 +121,11 @@ describe("SpokePool Depositor Logic", async function () {
       spokePool
         .connect(depositor)
         .deposit(
-          erc20.address,
-          destinationChainId,
-          amountToDeposit,
           recipient.address,
+          erc20.address,
+          amountToDeposit,
           depositRelayerFeePct,
+          destinationChainId,
           currentSpokePoolTime
         )
     ).to.be.reverted;
@@ -136,11 +136,11 @@ describe("SpokePool Depositor Logic", async function () {
       spokePool
         .connect(depositor)
         .deposit(
-          unwhitelistedErc20.address,
-          destinationChainId,
-          amountToDeposit,
           recipient.address,
+          unwhitelistedErc20.address,
+          amountToDeposit,
           depositRelayerFeePct,
+          destinationChainId,
           currentSpokePoolTime
         )
     ).to.be.reverted;
@@ -151,11 +151,11 @@ describe("SpokePool Depositor Logic", async function () {
       spokePool
         .connect(depositor)
         .deposit(
-          erc20.address,
-          destinationChainId,
-          amountToDeposit,
           recipient.address,
+          erc20.address,
+          amountToDeposit,
           depositRelayerFeePct,
+          destinationChainId,
           currentSpokePoolTime
         )
     ).to.be.reverted;
@@ -165,11 +165,11 @@ describe("SpokePool Depositor Logic", async function () {
     // Cannot deposit with invalid relayer fee.
     await expect(
       spokePool.connect(depositor).deposit(
-        erc20.address,
-        destinationChainId,
-        amountToDeposit,
         recipient.address,
+        erc20.address,
+        amountToDeposit,
         toWei("1"), // Fee > 50%
+        destinationChainId,
         currentSpokePoolTime
       )
     ).to.be.reverted;
@@ -177,21 +177,21 @@ describe("SpokePool Depositor Logic", async function () {
     // Cannot deposit invalid quote fee.
     await expect(
       spokePool.connect(depositor).deposit(
-        erc20.address,
-        destinationChainId,
-        amountToDeposit,
         recipient.address,
+        erc20.address,
+        amountToDeposit,
         depositRelayerFeePct,
+        destinationChainId,
         toBN(currentSpokePoolTime).add(toBN("700")) // > 10 mins in future
       )
     ).to.be.reverted;
     await expect(
       spokePool.connect(depositor).deposit(
-        erc20.address,
-        destinationChainId,
-        amountToDeposit,
         recipient.address,
+        erc20.address,
+        amountToDeposit,
         depositRelayerFeePct,
+        destinationChainId,
         toBN(currentSpokePoolTime).sub(toBN("700")) // > 10 mins in past
       )
     ).to.be.reverted;

--- a/test/SpokePool.Fixture.ts
+++ b/test/SpokePool.Fixture.ts
@@ -25,7 +25,7 @@ export const spokePoolFixture = hre.deployments.createFixture(async ({ ethers })
   const merkleLib = await (await getContractFactory("MerkleLib", deployerWallet)).deploy();
   const spokePool = await (
     await getContractFactory("MockSpokePool", { signer: deployerWallet, libraries: { MerkleLib: merkleLib.address } })
-  ).deploy(crossChainAdmin.address, hubPool.address, weth.address, timer.address, consts.depositQuoteTimeBuffer);
+  ).deploy(crossChainAdmin.address, hubPool.address, weth.address, timer.address);
 
   return { timer, weth, erc20, spokePool, unwhitelistedErc20, destErc20 };
 });

--- a/test/SpokePool.Relay.ts
+++ b/test/SpokePool.Relay.ts
@@ -1,5 +1,12 @@
 import { expect, Contract, ethers, SignerWithAddress, seedWallet, toWei, toBN } from "./utils";
-import { spokePoolFixture, enableRoutes, getRelayHash, modifyRelayHelper } from "./SpokePool.Fixture";
+import {
+  spokePoolFixture,
+  enableRoutes,
+  getRelayHash,
+  modifyRelayHelper,
+  getFillRelayParams,
+  getFillRelayUpdatedFeeParams,
+} from "./SpokePool.Fixture";
 import * as consts from "./constants";
 
 let spokePool: Contract, weth: Contract, erc20: Contract, destErc20: Contract;
@@ -24,7 +31,7 @@ describe("SpokePool Relayer Logic", async function () {
     await enableRoutes(spokePool, [{ originToken: erc20.address }, { originToken: weth.address }]);
   });
   it("Relaying ERC20 tokens correctly pulls tokens and changes contract state", async function () {
-    const { relayHash, relayData, relayDataValues } = getRelayHash(
+    const { relayHash, relayData } = getRelayHash(
       depositor.address,
       recipient.address,
       consts.firstDepositId,
@@ -32,20 +39,18 @@ describe("SpokePool Relayer Logic", async function () {
       destErc20.address
     );
 
-    await expect(
-      spokePool.connect(relayer).fillRelay(...relayDataValues, consts.amountToRelay, consts.repaymentChainId)
-    )
+    await expect(spokePool.connect(relayer).fillRelay(...getFillRelayParams(relayData, consts.amountToRelay)))
       .to.emit(spokePool, "FilledRelay")
       .withArgs(
         relayHash,
         relayData.relayAmount,
         consts.amountToRelayPreFees,
         consts.amountToRelayPreFees,
-        consts.repaymentChainId,
-        relayData.originChainId,
-        relayData.depositId,
         relayData.relayerFeePct,
         relayData.realizedLpFeePct,
+        consts.repaymentChainId,
+        toBN(relayData.originChainId),
+        toBN(relayData.depositId),
         relayData.destinationToken,
         relayer.address,
         relayData.depositor,
@@ -63,25 +68,7 @@ describe("SpokePool Relayer Logic", async function () {
     // pulls exactly enough tokens to complete the relay.
     const fullRelayAmount = consts.amountToDeposit;
     const fullRelayAmountPostFees = fullRelayAmount.mul(consts.totalPostFeesPct).div(toBN(consts.oneHundredPct));
-    const amountRemainingInRelay = fullRelayAmount.sub(consts.amountToRelayPreFees);
-    // const amountRemainingInRelayPostFees = amountRemainingInRelay.mul(totalPostFeesPct).div(toBN(oneHundredPct));
-    await expect(spokePool.connect(relayer).fillRelay(...relayDataValues, fullRelayAmount, consts.repaymentChainId))
-      .to.emit(spokePool, "FilledRelay")
-      .withArgs(
-        relayHash,
-        relayData.relayAmount,
-        fullRelayAmount,
-        amountRemainingInRelay,
-        consts.repaymentChainId,
-        relayData.originChainId,
-        relayData.depositId,
-        relayData.relayerFeePct,
-        relayData.realizedLpFeePct,
-        relayData.destinationToken,
-        relayer.address,
-        relayData.depositor,
-        relayData.recipient
-      );
+    await spokePool.connect(relayer).fillRelay(...getFillRelayParams(relayData, fullRelayAmount));
     expect(await destErc20.balanceOf(relayer.address)).to.equal(
       consts.amountToSeedWallets.sub(fullRelayAmountPostFees)
     );
@@ -91,7 +78,7 @@ describe("SpokePool Relayer Logic", async function () {
     expect(await spokePool.relayFills(relayHash)).to.equal(fullRelayAmount);
   });
   it("Relaying WETH correctly unwraps into ETH", async function () {
-    const { relayHash, relayData, relayDataValues } = getRelayHash(
+    const { relayHash, relayData } = getRelayHash(
       depositor.address,
       recipient.address,
       consts.firstDepositId,
@@ -100,25 +87,7 @@ describe("SpokePool Relayer Logic", async function () {
     );
 
     const startingRecipientBalance = await recipient.getBalance();
-    await expect(
-      spokePool.connect(relayer).fillRelay(...relayDataValues, consts.amountToRelay, consts.repaymentChainId)
-    )
-      .to.emit(spokePool, "FilledRelay")
-      .withArgs(
-        relayHash,
-        relayData.relayAmount,
-        consts.amountToRelayPreFees,
-        consts.amountToRelayPreFees,
-        consts.repaymentChainId,
-        relayData.originChainId,
-        relayData.depositId,
-        relayData.relayerFeePct,
-        relayData.realizedLpFeePct,
-        relayData.destinationToken,
-        relayer.address,
-        relayData.depositor,
-        relayData.recipient
-      );
+    await spokePool.connect(relayer).fillRelay(...getFillRelayParams(relayData, consts.amountToRelay));
 
     // The collateral should have unwrapped to ETH and then transferred to recipient.
     expect(await weth.balanceOf(relayer.address)).to.equal(consts.amountToSeedWallets.sub(consts.amountToRelay));
@@ -133,72 +102,78 @@ describe("SpokePool Relayer Logic", async function () {
       spokePool
         .connect(relayer)
         .fillRelay(
-          ...getRelayHash(
-            depositor.address,
-            recipient.address,
-            consts.firstDepositId,
-            consts.originChainId,
-            destErc20.address,
-            consts.amountToDeposit.toString(),
-            toWei("0.5").toString(),
-            consts.depositRelayerFeePct.toString()
-          ).relayDataValues,
-          consts.amountToRelay,
-          consts.repaymentChainId
+          ...getFillRelayParams(
+            getRelayHash(
+              depositor.address,
+              recipient.address,
+              consts.firstDepositId,
+              consts.originChainId,
+              destErc20.address,
+              consts.amountToDeposit.toString(),
+              toWei("0.5").toString(),
+              consts.depositRelayerFeePct.toString()
+            ).relayData,
+            consts.amountToRelay,
+            consts.repaymentChainId
+          )
         )
     ).to.be.revertedWith("invalid fees");
     await expect(
       spokePool
         .connect(relayer)
         .fillRelay(
-          ...getRelayHash(
-            depositor.address,
-            recipient.address,
-            consts.firstDepositId,
-            consts.originChainId,
-            destErc20.address,
-            consts.amountToDeposit.toString(),
-            consts.realizedLpFeePct.toString(),
-            toWei("0.5").toString()
-          ).relayDataValues,
-          consts.amountToRelay,
-          consts.repaymentChainId
+          ...getFillRelayParams(
+            getRelayHash(
+              depositor.address,
+              recipient.address,
+              consts.firstDepositId,
+              consts.originChainId,
+              destErc20.address,
+              consts.amountToDeposit.toString(),
+              consts.realizedLpFeePct.toString(),
+              toWei("0.5").toString()
+            ).relayData,
+            consts.amountToRelay,
+            consts.repaymentChainId
+          )
         )
     ).to.be.revertedWith("invalid fees");
 
     // Relay already filled
     await spokePool.connect(relayer).fillRelay(
-      ...getRelayHash(
-        depositor.address,
-        recipient.address,
-        consts.firstDepositId,
-        consts.originChainId,
-        destErc20.address
-      ).relayDataValues,
-      consts.amountToDeposit, // Send the full relay amount
-      consts.repaymentChainId
+      ...getFillRelayParams(
+        getRelayHash(
+          depositor.address,
+          recipient.address,
+          consts.firstDepositId,
+          consts.originChainId,
+          destErc20.address
+        ).relayData,
+        consts.amountToDeposit, // Send the full relay amount
+        consts.repaymentChainId
+      )
     );
     await expect(
-      spokePool
-        .connect(relayer)
-        .fillRelay(
-          ...getRelayHash(
+      spokePool.connect(relayer).fillRelay(
+        ...getFillRelayParams(
+          getRelayHash(
             depositor.address,
             recipient.address,
             consts.firstDepositId,
             consts.originChainId,
             destErc20.address
-          ).relayDataValues,
-          "1",
+          ).relayData,
+          toBN("1"), // relay any amount
           consts.repaymentChainId
         )
+      )
     ).to.be.revertedWith("relay filled");
   });
   it("Can fill relay with updated fee by including proof of depositor's agreement", async function () {
     // The relay should succeed just like before with the same amount of tokens pulled from the relayer's wallet,
     // however the filled amount should have increased since the proportion of the relay filled would increase with a
     // higher fee.
-    const { relayHash, relayData, relayDataValues } = getRelayHash(
+    const { relayHash, relayData } = getRelayHash(
       depositor.address,
       recipient.address,
       consts.firstDepositId,
@@ -211,28 +186,10 @@ describe("SpokePool Relayer Logic", async function () {
       relayData.originChainId,
       depositor
     );
-    // Note: modifiedRelayFeePct is inserted in-place into middle of the same params passed to fillRelay
-    relayDataValues.splice(5, 0, consts.modifiedRelayerFeePct.toString());
-    await expect(
-      spokePool
-        .connect(relayer)
-        .fillRelayWithUpdatedFee(...relayDataValues, consts.amountToRelay, consts.repaymentChainId, signature)
-    )
-      .to.emit(spokePool, "FilledRelay")
-      .withArgs(
-        relayHash,
-        relayData.relayAmount,
-        consts.amountToRelayPreModifiedFees,
-        consts.amountToRelayPreModifiedFees,
-        consts.repaymentChainId,
-        relayData.originChainId,
-        relayData.depositId,
-        consts.modifiedRelayerFeePct, // The relayer fee % emitted in event should change
-        relayData.realizedLpFeePct,
-        relayData.destinationToken,
-        relayer.address,
-        relayData.depositor,
-        relayData.recipient
+    await spokePool
+      .connect(relayer)
+      .fillRelayWithUpdatedFee(
+        ...getFillRelayUpdatedFeeParams(relayData, consts.amountToRelay, consts.modifiedRelayerFeePct, signature)
       );
 
     // The collateral should have transferred from relayer to recipient.
@@ -243,15 +200,13 @@ describe("SpokePool Relayer Logic", async function () {
     expect(await spokePool.relayFills(relayHash)).to.equal(consts.amountToRelayPreModifiedFees);
   });
   it("Updating relayer fee signature verification failure cases", async function () {
-    const { relayDataValues, relayData } = getRelayHash(
+    const { relayData } = getRelayHash(
       depositor.address,
       recipient.address,
       consts.firstDepositId,
       consts.originChainId,
       destErc20.address
     );
-    // Note: modifiedRelayFeePct is inserted in-place into middle of the same params passed to fillRelay
-    relayDataValues.splice(5, 0, consts.modifiedRelayerFeePct.toString());
 
     // Message hash doesn't contain the modified fee passed as a function param.
     const { signature: incorrectFeeSignature } = await modifyRelayHelper(
@@ -264,16 +219,18 @@ describe("SpokePool Relayer Logic", async function () {
       spokePool
         .connect(relayer)
         .fillRelayWithUpdatedFee(
-          ...relayDataValues,
-          consts.amountToRelay,
-          consts.repaymentChainId,
-          incorrectFeeSignature
+          ...getFillRelayUpdatedFeeParams(
+            relayData,
+            consts.amountToRelay,
+            consts.modifiedRelayerFeePct,
+            incorrectFeeSignature
+          )
         )
     ).to.be.revertedWith("invalid signature");
 
     // Relay data depositID and originChainID don't match data included in relay hash
     const { signature: incorrectDepositIdSignature } = await modifyRelayHelper(
-      consts.incorrectModifiedRelayerFeePct,
+      consts.modifiedRelayerFeePct,
       relayData.depositId + "1",
       relayData.originChainId,
       depositor
@@ -282,14 +239,16 @@ describe("SpokePool Relayer Logic", async function () {
       spokePool
         .connect(relayer)
         .fillRelayWithUpdatedFee(
-          ...relayDataValues,
-          consts.amountToRelay,
-          consts.repaymentChainId,
-          incorrectDepositIdSignature
+          ...getFillRelayUpdatedFeeParams(
+            relayData,
+            consts.amountToRelay,
+            consts.modifiedRelayerFeePct,
+            incorrectDepositIdSignature
+          )
         )
     ).to.be.revertedWith("invalid signature");
     const { signature: incorrectChainIdSignature } = await modifyRelayHelper(
-      consts.incorrectModifiedRelayerFeePct,
+      consts.modifiedRelayerFeePct,
       relayData.depositId,
       relayData.originChainId + "1",
       depositor
@@ -298,10 +257,12 @@ describe("SpokePool Relayer Logic", async function () {
       spokePool
         .connect(relayer)
         .fillRelayWithUpdatedFee(
-          ...relayDataValues,
-          consts.amountToRelay,
-          consts.repaymentChainId,
-          incorrectChainIdSignature
+          ...getFillRelayUpdatedFeeParams(
+            relayData,
+            consts.amountToRelay,
+            consts.modifiedRelayerFeePct,
+            incorrectChainIdSignature
+          )
         )
     ).to.be.revertedWith("invalid signature");
 
@@ -316,10 +277,12 @@ describe("SpokePool Relayer Logic", async function () {
       spokePool
         .connect(relayer)
         .fillRelayWithUpdatedFee(
-          ...relayDataValues,
-          consts.amountToRelay,
-          consts.repaymentChainId,
-          incorrectSignerSignature
+          ...getFillRelayUpdatedFeeParams(
+            relayData,
+            consts.amountToRelay,
+            consts.modifiedRelayerFeePct,
+            incorrectSignerSignature
+          )
         )
     ).to.be.revertedWith("invalid signature");
   });

--- a/test/SpokePool.SlowRelay.ts
+++ b/test/SpokePool.SlowRelay.ts
@@ -12,15 +12,12 @@ import {
   defaultAbiCoder,
   keccak256,
 } from "./utils";
-import { spokePoolFixture, enableRoutes, getRelayHash, modifyRelayHelper, RelayData } from "./SpokePool.Fixture";
+import { spokePoolFixture, enableRoutes, RelayData } from "./SpokePool.Fixture";
 import { MerkleTree } from "../utils/MerkleTree";
 import * as consts from "./constants";
 
 let spokePool: Contract, weth: Contract, erc20: Contract, destErc20: Contract;
-let depositor: SignerWithAddress,
-  recipient: SignerWithAddress,
-  relayer: SignerWithAddress,
-  slowRelayer: SignerWithAddress;
+let depositor: SignerWithAddress, recipient: SignerWithAddress, relayer: SignerWithAddress;
 let relays: RelayData[];
 let tree: MerkleTree<RelayData>;
 
@@ -28,7 +25,7 @@ const fullRelayAmountPostFees = consts.amountToRelay.mul(consts.totalPostFeesPct
 
 describe("SpokePool Slow Relay Logic", async function () {
   beforeEach(async function () {
-    [depositor, recipient, relayer, slowRelayer] = await ethers.getSigners();
+    [depositor, recipient, relayer] = await ethers.getSigners();
     ({ weth, erc20, spokePool, destErc20 } = await spokePoolFixture());
 
     // mint some fresh tokens and deposit ETH for weth for depositor and relayer.
@@ -54,11 +51,11 @@ describe("SpokePool Slow Relay Logic", async function () {
         depositor: randomAddress(),
         recipient: randomAddress(),
         destinationToken: randomAddress(),
+        relayAmount: randomBigNumber().toString(),
         realizedLpFeePct: randomBigNumber(8).toString(),
         relayerFeePct: randomBigNumber(8).toString(),
-        depositId: randomBigNumber(8).toString(),
-        originChainId: randomBigNumber().toString(),
-        relayAmount: randomBigNumber().toString(),
+        depositId: randomBigNumber(2).toString(),
+        originChainId: randomBigNumber(2).toString(),
       });
     }
 
@@ -67,11 +64,11 @@ describe("SpokePool Slow Relay Logic", async function () {
       depositor: depositor.address,
       recipient: recipient.address,
       destinationToken: destErc20.address,
+      relayAmount: consts.amountToRelay.toString(),
       realizedLpFeePct: consts.realizedLpFeePct.toString(),
       relayerFeePct: consts.depositRelayerFeePct.toString(),
       depositId: consts.firstDepositId.toString(),
       originChainId: consts.originChainId.toString(),
-      relayAmount: consts.amountToRelay.toString(),
     });
 
     // WETH
@@ -79,11 +76,11 @@ describe("SpokePool Slow Relay Logic", async function () {
       depositor: depositor.address,
       recipient: recipient.address,
       destinationToken: weth.address,
+      relayAmount: consts.amountToRelay.toString(),
       realizedLpFeePct: consts.realizedLpFeePct.toString(),
       relayerFeePct: consts.depositRelayerFeePct.toString(),
       depositId: consts.firstDepositId.toString(),
       originChainId: consts.originChainId.toString(),
-      relayAmount: consts.amountToRelay.toString(),
     });
 
     const paramType = await getParamType("MerkleLib", "verifySlowRelayFulfillment", "slowRelayFulfillment");
@@ -102,11 +99,11 @@ describe("SpokePool Slow Relay Logic", async function () {
           depositor.address,
           recipient.address,
           destErc20.address,
+          consts.amountToRelay,
           consts.realizedLpFeePct,
           consts.depositRelayerFeePct,
           consts.firstDepositId,
           consts.originChainId,
-          consts.amountToRelay,
           0,
           tree.getHexProof(relays.find((relay) => relay.destinationToken === destErc20.address)!)
         )
@@ -127,11 +124,11 @@ describe("SpokePool Slow Relay Logic", async function () {
           depositor.address,
           recipient.address,
           destErc20.address,
+          consts.amountToRelay,
           consts.realizedLpFeePct,
           consts.depositRelayerFeePct,
           consts.firstDepositId,
           consts.originChainId,
-          consts.amountToRelay,
           0,
           tree.getHexProof(relays.find((relay) => relay.destinationToken === destErc20.address)!)
         )
@@ -142,10 +139,10 @@ describe("SpokePool Slow Relay Logic", async function () {
         consts.amountToRelay,
         consts.amountToRelay,
         consts.amountToRelay,
-        consts.originChainId,
-        consts.firstDepositId,
         consts.depositRelayerFeePct,
         consts.realizedLpFeePct,
+        consts.originChainId,
+        consts.firstDepositId,
         destErc20.address,
         relayer.address,
         depositor.address,
@@ -161,11 +158,11 @@ describe("SpokePool Slow Relay Logic", async function () {
           depositor.address,
           recipient.address,
           weth.address,
+          consts.amountToRelay,
           consts.realizedLpFeePct,
           consts.depositRelayerFeePct,
           consts.firstDepositId,
           consts.originChainId,
-          consts.amountToRelay,
           0,
           tree.getHexProof(relays.find((relay) => relay.destinationToken === weth.address)!)
         )
@@ -180,11 +177,11 @@ describe("SpokePool Slow Relay Logic", async function () {
           depositor.address,
           recipient.address,
           weth.address,
+          consts.amountToRelay,
           consts.realizedLpFeePct,
           consts.depositRelayerFeePct,
           consts.firstDepositId,
           consts.originChainId,
-          consts.amountToRelay,
           0,
           tree.getHexProof(relays.find((relay) => relay.destinationToken === weth.address)!)
         )
@@ -201,11 +198,11 @@ describe("SpokePool Slow Relay Logic", async function () {
           depositor.address,
           recipient.address,
           weth.address,
+          consts.amountToRelay,
           consts.realizedLpFeePct,
           consts.depositRelayerFeePct,
           consts.firstDepositId,
           consts.originChainId,
-          consts.amountToRelay,
           0,
           tree.getHexProof(relays.find((relay) => relay.destinationToken === weth.address)!)
         )
@@ -216,10 +213,10 @@ describe("SpokePool Slow Relay Logic", async function () {
         consts.amountToRelay,
         consts.amountToRelay,
         consts.amountToRelay,
-        consts.originChainId,
-        consts.firstDepositId,
         consts.depositRelayerFeePct,
         consts.realizedLpFeePct,
+        consts.originChainId,
+        consts.firstDepositId,
         weth.address,
         relayer.address,
         depositor.address,
@@ -237,13 +234,13 @@ describe("SpokePool Slow Relay Logic", async function () {
         depositor.address,
         recipient.address,
         destErc20.address,
-        consts.realizedLpFeePct,
-        consts.depositRelayerFeePct,
-        consts.firstDepositId,
-        consts.originChainId,
         consts.amountToRelay,
         partialAmountPostFees,
-        consts.repaymentChainId
+        consts.realizedLpFeePct,
+        consts.depositRelayerFeePct,
+        consts.repaymentChainId,
+        consts.firstDepositId,
+        consts.originChainId
       );
     await expect(() =>
       spokePool
@@ -252,11 +249,11 @@ describe("SpokePool Slow Relay Logic", async function () {
           depositor.address,
           recipient.address,
           destErc20.address,
+          consts.amountToRelay,
           consts.realizedLpFeePct,
           consts.depositRelayerFeePct,
           consts.firstDepositId,
           consts.originChainId,
-          consts.amountToRelay,
           0,
           tree.getHexProof(relays.find((relay) => relay.destinationToken === destErc20.address)!)
         )
@@ -274,13 +271,13 @@ describe("SpokePool Slow Relay Logic", async function () {
         depositor.address,
         recipient.address,
         destErc20.address,
-        consts.realizedLpFeePct,
-        consts.depositRelayerFeePct,
-        consts.firstDepositId,
-        consts.originChainId,
         consts.amountToRelay,
         partialAmountPostFees,
-        consts.repaymentChainId
+        consts.realizedLpFeePct,
+        consts.depositRelayerFeePct,
+        consts.repaymentChainId,
+        consts.firstDepositId,
+        consts.originChainId
       );
 
     await expect(
@@ -290,11 +287,11 @@ describe("SpokePool Slow Relay Logic", async function () {
           depositor.address,
           recipient.address,
           destErc20.address,
+          consts.amountToRelay,
           consts.realizedLpFeePct,
           consts.depositRelayerFeePct,
           consts.firstDepositId,
           consts.originChainId,
-          consts.amountToRelay,
           0,
           tree.getHexProof(relays.find((relay) => relay.destinationToken === destErc20.address)!)
         )
@@ -305,10 +302,10 @@ describe("SpokePool Slow Relay Logic", async function () {
         consts.amountToRelay,
         consts.amountToRelay,
         leftoverPreFees,
-        consts.originChainId,
-        consts.firstDepositId,
         consts.depositRelayerFeePct,
         consts.realizedLpFeePct,
+        consts.originChainId,
+        consts.firstDepositId,
         destErc20.address,
         relayer.address,
         depositor.address,
@@ -326,13 +323,13 @@ describe("SpokePool Slow Relay Logic", async function () {
         depositor.address,
         recipient.address,
         weth.address,
-        consts.realizedLpFeePct,
-        consts.depositRelayerFeePct,
-        consts.firstDepositId,
-        consts.originChainId,
         consts.amountToRelay,
         partialAmountPostFees,
-        consts.repaymentChainId
+        consts.realizedLpFeePct,
+        consts.depositRelayerFeePct,
+        consts.repaymentChainId,
+        consts.firstDepositId,
+        consts.originChainId
       );
 
     await expect(() =>
@@ -342,11 +339,11 @@ describe("SpokePool Slow Relay Logic", async function () {
           depositor.address,
           recipient.address,
           weth.address,
+          consts.amountToRelay,
           consts.realizedLpFeePct,
           consts.depositRelayerFeePct,
           consts.firstDepositId,
           consts.originChainId,
-          consts.amountToRelay,
           0,
           tree.getHexProof(relays.find((relay) => relay.destinationToken === weth.address)!)
         )
@@ -363,13 +360,13 @@ describe("SpokePool Slow Relay Logic", async function () {
         depositor.address,
         recipient.address,
         weth.address,
-        consts.realizedLpFeePct,
-        consts.depositRelayerFeePct,
-        consts.firstDepositId,
-        consts.originChainId,
         consts.amountToRelay,
         partialAmountPostFees,
-        consts.repaymentChainId
+        consts.realizedLpFeePct,
+        consts.depositRelayerFeePct,
+        consts.repaymentChainId,
+        consts.firstDepositId,
+        consts.originChainId
       );
 
     await expect(() =>
@@ -379,11 +376,11 @@ describe("SpokePool Slow Relay Logic", async function () {
           depositor.address,
           recipient.address,
           weth.address,
+          consts.amountToRelay,
           consts.realizedLpFeePct,
           consts.depositRelayerFeePct,
           consts.firstDepositId,
           consts.originChainId,
-          consts.amountToRelay,
           0,
           tree.getHexProof(relays.find((relay) => relay.destinationToken === weth.address)!)
         )
@@ -401,13 +398,13 @@ describe("SpokePool Slow Relay Logic", async function () {
         depositor.address,
         recipient.address,
         weth.address,
-        consts.realizedLpFeePct,
-        consts.depositRelayerFeePct,
-        consts.firstDepositId,
-        consts.originChainId,
         consts.amountToRelay,
         partialAmountPostFees,
-        consts.repaymentChainId
+        consts.realizedLpFeePct,
+        consts.depositRelayerFeePct,
+        consts.repaymentChainId,
+        consts.firstDepositId,
+        consts.originChainId
       );
 
     await expect(
@@ -417,11 +414,11 @@ describe("SpokePool Slow Relay Logic", async function () {
           depositor.address,
           recipient.address,
           weth.address,
+          consts.amountToRelay,
           consts.realizedLpFeePct,
           consts.depositRelayerFeePct,
           consts.firstDepositId,
           consts.originChainId,
-          consts.amountToRelay,
           0,
           tree.getHexProof(relays.find((relay) => relay.destinationToken === weth.address)!)
         )
@@ -432,10 +429,10 @@ describe("SpokePool Slow Relay Logic", async function () {
         consts.amountToRelay,
         consts.amountToRelay,
         leftoverPreFees,
-        consts.originChainId,
-        consts.firstDepositId,
         consts.depositRelayerFeePct,
         consts.realizedLpFeePct,
+        consts.originChainId,
+        consts.firstDepositId,
         weth.address,
         relayer.address,
         depositor.address,
@@ -449,11 +446,11 @@ describe("SpokePool Slow Relay Logic", async function () {
         depositor.address,
         recipient.address,
         weth.address,
+        consts.amountToRelay.sub(1), // Slightly modify the relay data from the expected set.
         consts.realizedLpFeePct,
         consts.depositRelayerFeePct,
         consts.firstDepositId,
         consts.originChainId,
-        consts.amountToRelay.sub(1), // Slightly modify the relay data from the expected set.
         0,
         tree.getHexProof(relays.find((relay) => relay.destinationToken === weth.address)!)
       )

--- a/test/chain-adapters/Arbitrum_Adapter.ts
+++ b/test/chain-adapters/Arbitrum_Adapter.ts
@@ -76,7 +76,15 @@ describe("Arbitrum Chain Adapter", function () {
     // Create an action that will send an L1->L2 tokens transfer and bundle. For this, create a relayer repayment bundle
     // and check that at it's finalization the L2 bridge contracts are called as expected.
     const { leafs, tree, tokensSendToL2 } = await constructSingleChainTree(dai, 1, arbitrumChainId);
-    await hubPool.connect(dataWorker).initiateRelayerRefund([3117], 1, tree.getHexRoot(), consts.mockTreeRoot);
+    await hubPool
+      .connect(dataWorker)
+      .initiateRelayerRefund(
+        [3117],
+        1,
+        tree.getHexRoot(),
+        consts.mockDestinationDistributionRoot,
+        consts.mockSlowRelayFulfillmentRoot
+      );
     await timer.setCurrentTime(Number(await timer.getCurrentTime()) + consts.refundProposalLiveness);
     await hubPool.connect(dataWorker).executeRelayerRefund(leafs[0], tree.getHexProof(leafs[0]));
     // The correct functions should have been called on the arbitrum contracts.
@@ -99,7 +107,10 @@ describe("Arbitrum Chain Adapter", function () {
       owner.address,
       consts.sampleL2Gas,
       consts.sampleL2GasPrice,
-      mockSpoke.interface.encodeFunctionData("initializeRelayerRefund", [consts.mockTreeRoot])
+      mockSpoke.interface.encodeFunctionData("initializeRelayerRefund", [
+        consts.mockDestinationDistributionRoot,
+        consts.mockSlowRelayFulfillmentRoot,
+      ])
     );
   });
 });


### PR DESCRIPTION
Percentages and timestamp-based variables can be smaller size to save gas costs for storing data